### PR TITLE
Limit Explorer's Compass

### DIFF
--- a/config/explorerscompass-common.toml
+++ b/config/explorerscompass-common.toml
@@ -1,14 +1,14 @@
 
 [General]
 	#Allows a player to teleport to a located structure when in creative mode, opped, or in cheat mode.
-	allowTeleport = true
+	allowTeleport = false
 	#Allows players to view the precise coordinates and distance of a located structure on the HUD, rather than relying on the direction the compass is pointing.
 	displayCoordinates = true
 	#The maximum radius that will be searched for a structure. Raising this value will increase search accuracy but will potentially make the process more resource intensive.
 	#Range: 0 ~ 1000000
 	maxRadius = 5000
 	#A list of structures that the compass will not display in the GUI and will not be able to search for. Wildcard character * can be used to match any number of characters, and ? can be used to match one character. Ex: ["minecraft:stronghold", "minecraft:endcity", "minecraft:*village*"]
-	structureBlacklist = []
+	structureBlacklist = ["ae2*", "ars*", "byg*", "cloudstorage*", "ctov*", "dungeons_arise*", "hexerei*", "minecraft*", "repurposed_structures*", "the_bumblezone*", "twilightforest*", "supplementaries*", "blue_skies:village*", "blue_skies:gatekeeper*"]
 	#The maximum number of samples to be taken when searching for a structure.
 	#Range: 0 ~ 100000000
 	maxSamples = 100000

--- a/kubejs/client_scripts/base/jei_descriptions.js
+++ b/kubejs/client_scripts/base/jei_descriptions.js
@@ -144,6 +144,10 @@ JEIEvents.information((event) => {
         {
             items: ['naturesaura:birth_spirit'],
             text: [`Obtained by manually breeding animals in high Aura areas.`]
+        },
+        {
+            items: ['explorerscompass:explorerscompass'],
+            text: [`May only be used to locate Blue Skies structures.`]
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/explorerscompass/shaped.js
+++ b/kubejs/server_scripts/base/recipes/explorerscompass/shaped.js
@@ -1,0 +1,20 @@
+ServerEvents.recipes((event) => {
+    const id_prefex = 'enigmatica:base/explorerscompass/shaped/';
+
+    const recipes = [
+        {
+            output: 'explorerscompass:explorerscompass',
+            pattern: ['ABA', 'BCB', 'ABA'],
+            key: {
+                A: '#blue_skies:vines',
+                B: '#blue_skies:gems/moonstone',
+                C: '#forge:compasses'
+            },
+            id: `explorerscompass:explorers_compass`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});


### PR DESCRIPTION
Main goal with this is to help with Blue Skies progression. Therefore all other structures have been disabled from it. 

![image](https://user-images.githubusercontent.com/9543430/189227662-2207a401-63b7-46b8-8c3c-8fe6a3c160d0.png)

Also sets the recipe to use blue skies materials. 
![image](https://user-images.githubusercontent.com/9543430/189229090-6e0f2f95-b18e-4d91-92f5-3a259505a27e.png)

And sets a description for whenever that feature gets fixed in KubeJS :D
