### PR TITLE
Script cleanup

### DIFF
--- a/config/almostunified/unify.json
+++ b/config/almostunified/unify.json
@@ -22,7 +22,8 @@
         "forge:rods/{material}",
         "forge:storage_blocks/{material}",
         "forge:slag",
-        "forge:coal_coke"
+        "forge:coal_coke",
+        "forge:sawdust"
     ],
     "materials": [
         "aeternium",

--- a/kubejs/server_scripts/base/recipes/create/cutting.js
+++ b/kubejs/server_scripts/base/recipes/create/cutting.js
@@ -1,12 +1,12 @@
 ServerEvents.recipes((event) => {
-    const id_prefix = 'enigmatica:base/mekanism/sawing/';
+    const id_prefix = 'enigmatica:base/create/cutting/';
 
     const recipes = [
         /*
         {
-            input: [Item.of('minecraft:oak_log')],
-            mainOutput: Item.of('6x minecraft:stripped_oak_log'),
-            secondary: { output: Item.of('farmersdelight:tree_bark'), chance: 1.0 },
+            input: ['minecraft:acacia_wood'],
+            outputs: ['minecraft:stripped_acacia_wood'],
+            processingTime: 50,
             id: `${id_prefix}stripped_oak_log_from_oak_log`
         }
         */
@@ -19,18 +19,19 @@ ServerEvents.recipes((event) => {
         // Log to Stripped
         recipes.push({
             input: [Item.of(input)],
-            output: Item.of(output),
-            secondary: { output: Item.of(bark), chance: 1.0 },
+            outputs: [Item.of(output)],
+            processingTime: 50,
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
 
         input = material.wood.block;
         output = material.wood.stripped;
+
         // Wood to Stripped
         recipes.push({
             input: [Item.of(input)],
-            output: Item.of(output),
-            secondary: { output: Item.of(bark), chance: 1.0 },
+            outputs: [Item.of(output)],
+            processingTime: 50,
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
 
@@ -40,26 +41,20 @@ ServerEvents.recipes((event) => {
         // Stripped to Plank
         recipes.push({
             input: [Item.of(input), Item.of(material.wood.stripped)],
-            output: Item.of(output, 6),
-            secondary: { output: Item.of(sawdust), chance: 0.25 },
+            outputs: [Item.of(output, 6)],
+            processingTime: 50,
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
     });
 
     recipes.forEach((recipe) => {
-        recipe.type = 'mekanism:sawing';
+        recipe.type = 'create:cutting';
 
-        // input: { ingredient: [{ item: 'minecraft:oak_log' }] },
-        recipe.input = { ingredient: recipe.input.map((input) => input.toJson()) };
+        // ingredients:  [{ item: 'minecraft:oak_log' }],
+        recipe.ingredients = recipe.input.map((input) => input.toJson());
 
-        // mainOutput: { count: 6, item: 'minecraft:oak_planks' }
-        recipe.mainOutput = recipe.output.toJson();
-
-        // secondaryOutput: { item: 'farmersdelight:tree_bark' },
-        recipe.secondaryOutput = recipe.secondary.output.toJson();
-
-        // secondaryChance: 0.25,
-        recipe.secondaryChance = recipe.secondary.chance;
+        // results: [{ count: 6, item: 'minecraft:oak_planks' }]
+        recipe.results = recipe.outputs.map((output) => output.toJson());
 
         event.custom(recipe).id(recipe.id);
     });

--- a/kubejs/server_scripts/base/recipes/create/cutting.js
+++ b/kubejs/server_scripts/base/recipes/create/cutting.js
@@ -13,21 +13,19 @@ ServerEvents.recipes((event) => {
     ];
 
     wood_properties.forEach((material) => {
+        // Log to Stripped
         let input = material.log.block,
             output = material.log.stripped;
-
-        // Log to Stripped
         recipes.push({
             input: [Item.of(input)],
             outputs: [Item.of(output)],
             processingTime: 50,
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
-
-        input = material.wood.block;
-        output = material.wood.stripped;
 
         // Wood to Stripped
+        input = material.wood.block;
+        output = material.wood.stripped;
         recipes.push({
             input: [Item.of(input)],
             outputs: [Item.of(output)],
@@ -35,10 +33,9 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
 
+        // Stripped to Plank
         input = material.log.stripped;
         output = material.plank.block;
-
-        // Stripped to Plank
         recipes.push({
             input: [Item.of(input), Item.of(material.wood.stripped)],
             outputs: [Item.of(output, 6)],

--- a/kubejs/server_scripts/base/recipes/enigmatica/dye_crushing.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/dye_crushing.js
@@ -1,0 +1,116 @@
+//priority: 900
+
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/dye_crushing/';
+
+    colors.forEach((color) => {
+        ['large', 'small'].forEach((size) => {
+            let duration = 20;
+            let output = `minecraft:${color}_dye`;
+            let input = `#enigmatica:${size}_dye_sources/${color}`;
+            let id_suffix = `${size}_${color}_dye`;
+
+            // Shapeless
+            let base_count = 1;
+            let count = size == 'large' ? base_count * 2 : base_count;
+            event.shapeless(Item.of(output, count), [input]).id(`${id_prefix}shapeless/${id_suffix}`);
+
+            // Hexerei Mortar and Pestle
+            base_count = 15;
+            count = size == 'large' ? base_count * 2 : base_count;
+            event
+                .custom({
+                    type: 'hexerei:pestle_and_mortar',
+                    ingredients: [
+                        Ingredient.of(input).toJson(),
+                        Ingredient.of(input).toJson(),
+                        Ingredient.of(input).toJson(),
+                        Ingredient.of(input).toJson(),
+                        Ingredient.of(input).toJson()
+                    ],
+                    output: Item.of(output, count).toJson(),
+                    grindingTime: duration * 5
+                })
+                .id(`${id_prefix}hexerei/pestle_and_mortar/${id_suffix}`);
+
+            // Occultism Crushing
+            base_count = 3;
+            count = size == 'large' ? base_count * 2 : base_count;
+            event
+                .custom({
+                    type: 'occultism:crushing',
+                    ingredient: Ingredient.of(input).toJson(),
+                    result: Item.of(output, count).toJson(),
+                    crushing_time: duration,
+                    ignore_crushing_multiplier: false
+                })
+                .id(`${id_prefix}occultism_crushing/${id_suffix}`);
+
+            // Mekanism Enriching
+            event
+                .custom({
+                    type: 'mekanism:enriching',
+                    input: { ingredient: Ingredient.of(input).toJson() },
+                    output: Item.of(output, count).toJson()
+                })
+                .id(`${id_prefix}mekanism_enriching/${id_suffix}`);
+        });
+    });
+
+    dye_sources.forEach((dye_source) => {
+        let base_count = 3;
+        let count = dye_source.type == 'large' ? base_count * 2 : base_count;
+        let secondary_chance = dye_source.type == 'large' ? (base_count / 9) * 2 : base_count / 9;
+        let tertiary_chance = dye_source.type == 'large' ? (base_count / 18) * 2 : base_count / 18;
+
+        let outputs = {
+            primary: { item: dye_source.primary, count: count, chance: 1.0 },
+            secondary: { item: dye_source.secondary, count: Math.ceil(count / 2), chance: secondary_chance },
+            tertiary: { item: dye_source.tertiary, count: Math.ceil(count / 3), chance: tertiary_chance }
+        };
+
+        let input = dye_source.input;
+        let duration = 20;
+        let energy = 256;
+        let id_suffix = `${dye_source.primary.split(':')[1]}_from_${dye_source.input.split(':')[1]}`;
+
+        // Create
+        event
+            .custom({
+                type: 'create:milling',
+                ingredients: [Item.of(input).toJson()],
+                results: [outputs.primary, outputs.secondary, outputs.tertiary],
+                processingTime: duration
+            })
+            .id(`${id_prefix}create_milling/${id_suffix}`);
+
+        // Ars Nouveau
+        event
+            .custom({
+                type: 'ars_nouveau:crush',
+                input: Item.of(input).toJson(),
+                output: [outputs.primary, outputs.secondary, outputs.tertiary]
+            })
+            .id(`${id_prefix}ars_nouveau_crushing/${id_suffix}`);
+
+        // Immersive Engineering
+        event
+            .custom({
+                type: 'immersiveengineering:crusher',
+                energy: energy,
+                input: Item.of(input).toJson(),
+                result: { base_ingredient: { item: outputs.primary.item }, count: outputs.primary.count },
+                secondaries: [
+                    {
+                        output: Item.of(outputs.secondary.item, outputs.secondary.count).toJson(),
+                        chance: outputs.secondary.chance
+                    },
+                    {
+                        output: Item.of(outputs.tertiary.item, outputs.tertiary.count).toJson(),
+                        chance: outputs.tertiary.chance
+                    }
+                ]
+            })
+            .id(`${id_prefix}immersiveengineering_crusher/${id_suffix}`);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/enigmatica/dye_crushing.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/dye_crushing.js
@@ -4,20 +4,23 @@ ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/dye_crushing/';
 
     colors.forEach((color) => {
-        ['large', 'small'].forEach((size) => {
-            let duration = 20;
+        ['large', 'small'].forEach((input_size) => {
+            let input = `#enigmatica:${input_size}_dye_sources/${color}`;
+            if (Ingredient.of(input).stacks.isEmpty()) {
+                return;
+            }
             let output = `minecraft:${color}_dye`;
-            let input = `#enigmatica:${size}_dye_sources/${color}`;
-            let id_suffix = `${size}_${color}_dye`;
+            let duration = 20;
+            let id_suffix = `${input_size}_${color}_dye`;
 
             // Shapeless
             let base_count = 1;
-            let count = size == 'large' ? base_count * 2 : base_count;
+            let count = input_size == 'large' ? base_count * 2 : base_count;
             event.shapeless(Item.of(output, count), [input]).id(`${id_prefix}shapeless/${id_suffix}`);
 
             // Hexerei Mortar and Pestle
             base_count = 15;
-            count = size == 'large' ? base_count * 2 : base_count;
+            count = input_size == 'large' ? base_count * 2 : base_count;
             event
                 .custom({
                     type: 'hexerei:pestle_and_mortar',
@@ -35,7 +38,7 @@ ServerEvents.recipes((event) => {
 
             // Occultism Crushing
             base_count = 3;
-            count = size == 'large' ? base_count * 2 : base_count;
+            count = input_size == 'large' ? base_count * 2 : base_count;
             event
                 .custom({
                     type: 'occultism:crushing',

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -7,14 +7,14 @@ ServerEvents.recipes((event) => {
         //     mod: 'sample',
         //     id: 'sample'
         // }
+        { id: /ars_nouveau:.*_dye_/ },
         { id: /mekanism:enriching\/dye/ },
         { id: /mekanism:compat\/byg\/dye/ },
-        { id: /ars_nouveau:.*_dye_/ },
         { id: /mekanism:compat\/byg\/sawing\/log/ },
         { id: /mekanism:sawing\/log/ },
-        { id: /almostunified:u\/immersiveengineering\/sawmill\/.*_log/ },
-        { id: /immersiveengineering:cloche/ },
-        { id: /farmersdelight:integration\/immersiveengineering\/cloche/ }
+        { type: 'immersiveengineering:sawmill' },
+        { type: 'create:cutting' },
+        { type: 'immersiveengineering:cloche' }
     ];
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -7,15 +7,24 @@ ServerEvents.recipes((event) => {
         //     mod: 'sample',
         //     id: 'sample'
         // }
-        { id: /ars_nouveau:.*_dye_/ },
+        { id: /ars_nouveau:.*_dye/ },
         { id: /mekanism:enriching\/dye/ },
         { id: /mekanism:compat\/byg\/dye/ },
         { id: /mekanism:compat\/byg\/sawing\/log/ },
         { id: /mekanism:sawing\/log/ },
+        { id: 'quark:tweaks/smelting/bone_meal_utility' },
         { type: 'immersiveengineering:sawmill' },
         { type: 'create:cutting' },
         { type: 'immersiveengineering:cloche' }
     ];
+
+    colors.forEach((color) => {
+        recipes.push(
+            { type: 'create:milling', output: `minecraft:${color}_dye` },
+            { type: 'farmersdelight:cutting', output: `minecraft:${color}_dye` },
+            { type: 'minecraft:crafting_shapeless', output: `minecraft:${color}_dye` }
+        );
+    });
 
     recipes.forEach((recipe) => {
         event.remove(recipe);

--- a/kubejs/server_scripts/base/recipes/enigmatica/shapeless.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/shapeless.js
@@ -1,0 +1,9 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/enigmatica/shapeless/';
+
+    const recipes = [];
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/hexerei/pestle_and_mortar.js
+++ b/kubejs/server_scripts/base/recipes/hexerei/pestle_and_mortar.js
@@ -1,0 +1,31 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/hexerei/pestle_and_mortar/';
+
+    const recipes = [
+        /*
+        {
+            inputs: [
+                Item.of('hexerei:belladonna_flowers'),
+                Item.of('hexerei:belladonna_berries'),
+                Item.of('hexerei:belladonna_berries'),
+                Item.of('hexerei:belladonna_berries'),
+                Item.of('hexerei:sage')
+            ],
+            output: Item.of('hexerei:mindful_trance_blend'),
+            grindingTime: 300
+        }
+        */
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'hexerei:pestle_and_mortar';
+
+        // ingredients:  [{ item: 'minecraft:oak_log' }],
+        recipe.ingredients = recipe.inputs.map((input) => input.toJson());
+
+        // output: [{ count: 6, item: 'minecraft:oak_planks' }]
+        recipe.output = recipe.output.toJson();
+
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/immersiveengineering/cloche.js
+++ b/kubejs/server_scripts/base/recipes/immersiveengineering/cloche.js
@@ -1,7 +1,18 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/immersiveengineering/cloche/';
 
-    const recipes = [];
+    const recipes = [
+        /*
+        {
+            outputs: [Item.of('2x minecraft:wheat'), Item.of('minecraft:wheat_seeds')],
+            input: Item.of('minecraft:wheat_seeds'),
+            render: { type: 'crop', block: 'minecraft:wheat' },
+            soil: Item.of('minecraft:dirt'),
+            time: 800,
+            id: `${id_prefix}'minecraft_wheat'`
+        }
+        */
+    ];
 
     // Cloche additions from crop_properties constant
     let crop_types = Object.keys(crop_properties);
@@ -26,16 +37,16 @@ ServerEvents.recipes((event) => {
                 return;
             }
 
-            let results = [{ item: crop.plant, count: primary_count }];
+            let outputs = [Item.of(crop.plant, primary_count)];
 
             if (type.includes('_crops') && crop.seed !== 'minecraft:chorus_flower') {
-                results.push({ item: crop.seed, count: secondary_count });
+                outputs.push(Item.of(`${secondary_count}x ${crop.seed}`));
             }
             recipes.push({
-                results: results,
-                input: { item: crop.seed },
+                outputs: outputs,
+                input: Item.of(crop.seed),
                 render: crop.render,
-                soil: { tag: `enigmatica:soils/${crop.substrate}` },
+                soil: Ingredient.of(`#enigmatica:soils/${crop.substrate}`),
                 time: Math.trunc(growth_ticks),
                 id: `${id_prefix}${crop.plant.replace(':', '_')}`
             });
@@ -44,6 +55,16 @@ ServerEvents.recipes((event) => {
 
     recipes.forEach((recipe) => {
         recipe.type = 'immersiveengineering:cloche';
+
+        // input: { item: 'minecraft:wheat_seeds' },
+        recipe.input = recipe.input.toJson();
+
+        // results: [{ count: 2, item: 'minecraft:wheat' }, { item: 'minecraft:wheat_seeds' }]
+        recipe.results = recipe.outputs.map((output) => output.toJson());
+
+        //soil: { item: 'minecraft:dirt' }
+        recipe.soil = recipe.soil.toJson();
+
         event.custom(recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/base/recipes/immersiveengineering/sawmill.js
+++ b/kubejs/server_scripts/base/recipes/immersiveengineering/sawmill.js
@@ -1,44 +1,78 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/immersiveengineering/sawmill/';
-    const recipes = [];
 
-    wood_properties.forEach((wood_property) => {
-        let sawdust = 'mekanism:sawdust',
-            bark = 'farmersdelight:tree_bark',
-            output = wood_property.plank.block,
-            input_log = wood_property.log.block,
-            input_wood = wood_property.wood.block;
+    let sawdust = 'mekanism:sawdust', //AlmostUnified.getPreferredItemForTag('#forge:sawdust')
+        bark = 'farmersdelight:tree_bark';
 
-        recipes.push(
-            // Log to Plank
-            {
-                energy: 512,
-                input: [{ item: input_log }],
-                result: { count: 6, item: output },
-                secondaries: [
-                    { output: { item: bark }, stripping: true },
-                    { output: { item: sawdust }, stripping: false }
-                ],
-                stripped: { item: wood_property.log.stripped },
-                id: `${id_prefix}${output.split(':')[1]}_from_${input_log.split(':')[1]}`
-            },
-            // Wood to Plank
-            {
-                energy: 512,
-                input: [{ item: input_wood }],
-                result: { count: 6, item: output },
-                secondaries: [
-                    { output: { item: bark }, stripping: true },
-                    { output: { item: sawdust }, stripping: false }
-                ],
-                stripped: { item: wood_property.wood.stripped },
-                id: `${id_prefix}${output.split(':')[1]}_from_${input_wood.split(':')[1]}`
-            }
-        );
+    const recipes = [
+        /*
+        {
+            energy: 512,
+            input: Item.of('minecraft:oak_log'),
+            output: Item.of('6x minecraft:oak_planks'),
+            secondaries: [
+                { output: bark, stripping: true },
+                { output: sawdust, stripping: false }
+            ],
+            stripped: Item.of('minecraft:stripped_oak_log'),
+            id: `${id_prefix}oak_planks_from_oak_log`
+        }
+        */
+    ];
+
+    wood_properties.forEach((material) => {
+        let output = material.plank.block,
+            input = material.log.block;
+
+        // Log to Plank
+        recipes.push({
+            energy: 512,
+            input: [Item.of(input)],
+            output: Item.of(output, 6),
+            secondaries: [
+                { output: bark, stripping: true },
+                { output: sawdust, stripping: false }
+            ],
+            stripped: Item.of(material.log.stripped),
+            id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
+        });
+
+        // Wood to Plank
+        input = material.wood.block;
+        recipes.push({
+            energy: 512,
+            input: [Item.of(input)],
+            output: Item.of(output, 6),
+            secondaries: [
+                { output: bark, stripping: true },
+                { output: sawdust, stripping: false }
+            ],
+            stripped: Item.of(material.wood.stripped),
+            id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
+        });
     });
 
     recipes.forEach((recipe) => {
         recipe.type = 'immersiveengineering:sawmill';
+
+        // input: [{ item: 'minecraft:oak_log' }, { item: 'minecraft:oak_wood' }]
+        recipe.input = recipe.input.map((input) => input.toJson());
+
+        // result: { count: 6, item: 'minecraft:oak_planks' }
+        recipe.result = recipe.output.toJson();
+
+        // secondaries: [
+        //     { output: { tag: 'forge:dusts/wood' }, stripping: true },
+        //     { output: { tag: 'forge:dusts/wood' }, stripping: false }
+        // ]
+        recipe.secondaries = recipe.secondaries.map((secondary) => ({
+            output: { item: secondary.output },
+            stripping: secondary.stripping
+        }));
+
+        // stripped: { item: 'minecraft:stripped_oak_log' }
+        recipe.stripped = recipe.stripped.toJson();
+
         event.custom(recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/base/recipes/immersiveengineering/sawmill.js
+++ b/kubejs/server_scripts/base/recipes/immersiveengineering/sawmill.js
@@ -1,9 +1,6 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/immersiveengineering/sawmill/';
 
-    let sawdust = 'mekanism:sawdust', //AlmostUnified.getPreferredItemForTag('#forge:sawdust')
-        bark = 'farmersdelight:tree_bark';
-
     const recipes = [
         /*
         {

--- a/kubejs/server_scripts/base/recipes/immersiveengineering/sawmill.js
+++ b/kubejs/server_scripts/base/recipes/immersiveengineering/sawmill.js
@@ -18,10 +18,9 @@ ServerEvents.recipes((event) => {
     ];
 
     wood_properties.forEach((material) => {
+        // Log to Plank
         let output = material.plank.block,
             input = material.log.block;
-
-        // Log to Plank
         recipes.push({
             energy: 512,
             input: [Item.of(input)],

--- a/kubejs/server_scripts/base/recipes/mekanism/sawing.js
+++ b/kubejs/server_scripts/base/recipes/mekanism/sawing.js
@@ -1,47 +1,68 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/mekanism/sawing/';
-    const recipes = [];
+    let sawdust = 'mekanism:sawdust', //AlmostUnified.getPreferredItemForTag('#forge:sawdust')
+        bark = 'farmersdelight:tree_bark';
 
-    wood_properties.forEach((wood_property) => {
-        let sawdust = 'mekanism:sawdust',
-            bark = 'farmersdelight:tree_bark';
+    const recipes = [
+        /*
+        {
+            input: [Item.of('minecraft:oak_log')],
+            mainOutput: Item.of('6x minecraft:stripped_oak_log'),
+            secondary: { output: Item.of('farmersdelight:tree_bark'), chance: 1.0 },
+            id: `${id_prefix}stripped_oak_log_from_oak_log`
+        }
+        */
+    ];
 
-        recipes.push(
-            // Log to Stripped
-            {
-                input: { ingredient: [{ item: wood_property.log.block }] },
-                mainOutput: { count: 1, item: wood_property.log.stripped },
-                secondaryChance: 1.0,
-                secondaryOutput: { item: bark },
-                id: `${id_prefix}${wood_property.log.stripped.split(':')[1]}_from_${
-                    wood_property.log.block.split(':')[1]
-                }`
-            },
-            // Wood to Stripped
-            {
-                input: { ingredient: [{ item: wood_property.wood.block }] },
-                mainOutput: { count: 1, item: wood_property.wood.stripped },
-                secondaryChance: 1.0,
-                secondaryOutput: { item: bark },
-                id: `${id_prefix}${wood_property.wood.stripped.split(':')[1]}_from_${
-                    wood_property.wood.block.split(':')[1]
-                }`
-            },
-            // Stripped to Plank
-            {
-                input: { ingredient: [{ item: wood_property.log.stripped }, { item: wood_property.wood.stripped }] },
-                mainOutput: { count: 6, item: wood_property.plank.block },
-                secondaryChance: 0.25,
-                secondaryOutput: { item: sawdust },
-                id: `${id_prefix}${wood_property.plank.block.split(':')[1]}_from_${
-                    wood_property.log.stripped.split(':')[1]
-                }`
-            }
-        );
+    wood_properties.forEach((material) => {
+        let input = material.log.block,
+            output = material.log.stripped;
+
+        // Log to Stripped
+        recipes.push({
+            input: [Item.of(input)],
+            output: Item.of(`${output}`),
+            secondary: { output: Item.of(bark), chance: 1.0 },
+            id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
+        });
+
+        input = material.wood.block;
+        output = material.wood.stripped;
+        // Wood to Stripped
+        recipes.push({
+            input: [Item.of(input)],
+            output: Item.of(`${output}`),
+            secondary: { output: Item.of(bark), chance: 1.0 },
+            id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
+        });
+
+        input = material.log.stripped;
+        output = material.plank.block;
+
+        // Stripped to Plank
+        recipes.push({
+            input: [Item.of(input), Item.of(material.wood.stripped)],
+            output: Item.of(output, 6),
+            secondary: { output: Item.of(sawdust), chance: 0.25 },
+            id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
+        });
     });
 
     recipes.forEach((recipe) => {
         recipe.type = 'mekanism:sawing';
+
+        // input: { ingredient: [{ item: 'minecraft:oak_log' }] },
+        recipe.input = { ingredient: recipe.input.map((input) => input.toJson()) };
+
+        // mainOutput: { count: 6, item: 'minecraft:oak_planks' }
+        recipe.mainOutput = recipe.output.toJson();
+
+        // secondaryOutput: { item: 'farmersdelight:tree_bark' },
+        recipe.secondaryOutput = recipe.secondary.output.toJson();
+
+        // secondaryChance: 0.25,
+        recipe.secondaryChance = recipe.secondary.chance;
+
         event.custom(recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/base/recipes/mekanism/sawing.js
+++ b/kubejs/server_scripts/base/recipes/mekanism/sawing.js
@@ -13,10 +13,9 @@ ServerEvents.recipes((event) => {
     ];
 
     wood_properties.forEach((material) => {
+        // Log to Stripped
         let input = material.log.block,
             output = material.log.stripped;
-
-        // Log to Stripped
         recipes.push({
             input: [Item.of(input)],
             output: Item.of(output),
@@ -24,9 +23,9 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
 
+        // Wood to Stripped
         input = material.wood.block;
         output = material.wood.stripped;
-        // Wood to Stripped
         recipes.push({
             input: [Item.of(input)],
             output: Item.of(output),
@@ -34,10 +33,9 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}${output.replace(':', '_')}_from_${input.replace(':', '_')}`
         });
 
+        // Stripped to Plank
         input = material.log.stripped;
         output = material.plank.block;
-
-        // Stripped to Plank
         recipes.push({
             input: [Item.of(input), Item.of(material.wood.stripped)],
             output: Item.of(output, 6),

--- a/kubejs/server_scripts/base/tags/items/byg/dyes.js
+++ b/kubejs/server_scripts/base/tags/items/byg/dyes.js
@@ -1,0 +1,6 @@
+ServerEvents.tags('item', (event) => {
+    colors.forEach((color) => {
+        event.removeAll(`byg:${color}_dye`);
+        event.removeAll(`byg:double_${color}_dye`);
+    });
+});

--- a/kubejs/server_scripts/base/tags/items/enigmatica/dye_source.js
+++ b/kubejs/server_scripts/base/tags/items/enigmatica/dye_source.js
@@ -1,0 +1,9 @@
+ServerEvents.tags('item', (event) => {
+    dye_sources.forEach((dye_source) => {
+        let primary_color = dye_source.primary.split(':')[1].replace('_dye', '');
+
+        if (colors.includes(primary_color)) {
+            event.get(`enigmatica:${dye_source.type}_dye_sources/${primary_color}`).add(dye_source.input);
+        }
+    });
+});

--- a/kubejs/server_scripts/constants/dye_sources.js
+++ b/kubejs/server_scripts/constants/dye_sources.js
@@ -32,6 +32,13 @@ const dye_sources = [
         tertiary: 'minecraft:light_gray_dye'
     },
     {
+        input: 'minecraft:lapis_lazuli',
+        type: 'small',
+        primary: 'minecraft:blue_dye',
+        secondary: 'minecraft:blue_dye',
+        tertiary: 'minecraft:blue_dye'
+    },
+    {
         input: 'minecraft:bone',
         type: 'small',
         primary: 'minecraft:bone_meal',
@@ -242,6 +249,14 @@ const dye_sources = [
         tertiary: 'minecraft:gray_dye'
     },
     // Farmer's Delight
+
+    {
+        input: 'farmersdelight:tree_bark',
+        type: 'small',
+        primary: 'minecraft:brown_dye',
+        secondary: 'minecraft:brown_dye',
+        tertiary: 'minecraft:black_dye'
+    },
     {
         input: 'farmersdelight:wild_beetroots',
         type: 'small',
@@ -833,6 +848,58 @@ const dye_sources = [
         primary: 'minecraft:magenta_dye',
         secondary: 'minecraft:pink_dye',
         tertiary: 'minecraft:yellow_dye'
+    },
+
+    // Book Wyrms
+
+    {
+        input: 'bookwyrms:scale_grey',
+        type: 'small',
+        primary: 'minecraft:gray_dye',
+        secondary: 'minecraft:gray_dye',
+        tertiary: 'minecraft:gray_dye'
+    },
+    {
+        input: 'bookwyrms:scale_red',
+        type: 'small',
+        primary: 'minecraft:red_dye',
+        secondary: 'minecraft:red_dye',
+        tertiary: 'minecraft:red_dye'
+    },
+    {
+        input: 'bookwyrms:scale_orange',
+        type: 'small',
+        primary: 'minecraft:orange_dye',
+        secondary: 'minecraft:orange_dye',
+        tertiary: 'minecraft:orange_dye'
+    },
+    {
+        input: 'bookwyrms:scale_green',
+        type: 'small',
+        primary: 'minecraft:green_dye',
+        secondary: 'minecraft:green_dye',
+        tertiary: 'minecraft:green_dye'
+    },
+    {
+        input: 'bookwyrms:scale_blue',
+        type: 'small',
+        primary: 'minecraft:blue_dye',
+        secondary: 'minecraft:blue_dye',
+        tertiary: 'minecraft:blue_dye'
+    },
+    {
+        input: 'bookwyrms:scale_teal',
+        type: 'small',
+        primary: 'minecraft:light_blue_dye',
+        secondary: 'minecraft:light_blue_dye',
+        tertiary: 'minecraft:light_blue_dye'
+    },
+    {
+        input: 'bookwyrms:scale_purple',
+        type: 'small',
+        primary: 'minecraft:purple_dye',
+        secondary: 'minecraft:purple_dye',
+        tertiary: 'minecraft:purple_dye'
     }
 ];
 

--- a/kubejs/server_scripts/constants/wood_properties.js
+++ b/kubejs/server_scripts/constants/wood_properties.js
@@ -1,5 +1,8 @@
 //priority: 1000
 
+const sawdust = 'mekanism:sawdust'; //AlmostUnified.getPreferredItemForTag('#forge:sawdust')
+const bark = 'farmersdelight:tree_bark';
+
 // Used to populate the wood_variants_constructor constant - Add variants here to enable compat with various cutting mechanics.
 // Be aware that you may need to specify exceptions in the loop below for this to work properly.
 var wood_variants_constructor = [

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/blastfurnace_fuel.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/blastfurnace_fuel.js
@@ -5,7 +5,7 @@ ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:expert/immersiveengineering/blastfurnace_fuel/';
     const recipes = [
         {
-            input: '#forge:nuggets/horizonite',
+            input: Ingredient.of('#forge:nuggets/horizonite'),
             time: 64 * 20,
             id: `${id_prefix}horizonite_nugget`
         }
@@ -13,7 +13,10 @@ ServerEvents.recipes((event) => {
 
     recipes.forEach((recipe) => {
         recipe.type = 'immersiveengineering:blast_furnace_fuel';
-        recipe.input = Ingredient.of(recipe.input).toJson();
+
+        // input: { tag: 'forge:coal_coke' }
+        recipe.input = recipe.input.toJson();
+
         event.custom(recipe).id(recipe.id);
     });
 });


### PR DESCRIPTION
General cleanup to get back to using `Item.of()` and `Ingredient.of()` now that they seem to be working correctly (for the most part). Trying to make things more readable, overall. 

Also brings dye crushing and sawing to Create, as well as dye crushing to Hexerei. 