### PR TITLE
[Expert] Disable Blue Skies portals

### DIFF
--- a/kubejs/client_scripts/expert/jei_descriptions.js
+++ b/kubejs/client_scripts/expert/jei_descriptions.js
@@ -13,6 +13,10 @@ JEIEvents.information((event) => {
                 `● Ender Pearls`,
                 `● Bottles o' Enchanting`
             ]
+        },
+        {
+            items: ['blue_skies:turquoise_stonebrick', 'blue_skies:lunar_stonebrick'],
+            text: [`Blueskies Portals are disabled in Expert.`]
         }
     ];
 

--- a/kubejs/server_scripts/expert/block_events/disable_blueskies_portals.js
+++ b/kubejs/server_scripts/expert/block_events/disable_blueskies_portals.js
@@ -1,0 +1,11 @@
+BlockEvents.rightClicked((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    if (event.block.id == 'blue_skies:turquoise_stonebrick' || event.block.id == 'blue_skies:lunar_stonebrick') {
+        if (event.item.id == 'blue_skies:zeal_lighter') {
+            event.cancel();
+        }
+    }
+});


### PR DESCRIPTION
Disabling as they always route back to the Overworld, which won't work with expert progression.