### PR TITLE
Add Missing config to CF downloads, to allow Custom Main Menu to work.

### DIFF
--- a/automation/settings.ps1
+++ b/automation/settings.ps1
@@ -102,7 +102,6 @@ $CONFIGS_TO_REMOVE_FROM_CLIENT_FILES = @(
 	"betterendforge/client-config.toml",
 	"betterendforge/client.json",
 	"bloodmagic-client.toml",
-	"blue_skies-client.toml",
 	"cagedmobs-client.toml",
 	"cfm-client.toml",
 	"chiselsandbits-client.toml",


### PR DESCRIPTION
Resolves #100