### PR TITLE
Prevent equipment script from running twice on the same mob

### DIFF
--- a/kubejs/server_scripts/base/entity/spawned/equipment.js
+++ b/kubejs/server_scripts/base/entity/spawned/equipment.js
@@ -2,14 +2,27 @@ EntityEvents.spawned((event) => {
     if (!event.entity.isLiving()) {
         return;
     }
-    // Ignore Apotheosis bosses
-    let entity_data = event.entity.fullNBT;
-    if (entity_data.hasOwnProperty('ForgeData')) {
-        if (entity_data.ForgeData.hasOwnProperty('apoth.boss')) {
-            // console.log('Apotheosis Boss!');
-            return;
-        }
+    let entity_data;
+
+    if (!event.entity.fullNBT.hasOwnProperty('ForgeData')) {
+        entity_data = event.entity.fullNBT;
+        entity_data.ForgeData = {};
+        event.entity.fullNBT = entity_data;
     }
+
+    if (event.entity.fullNBT.ForgeData.hasOwnProperty('apoth.boss')) {
+        console.log(event.entity.fullNBT);
+        return;
+    }
+
+    // Check to prevent re-applying buffs to mobs 'spawned' by releasing from a soul gem.
+    if (event.entity.fullNBT.ForgeData.hasOwnProperty('enigmatica_equipment')) {
+        return;
+    }
+
+    entity_data = event.entity.fullNBT;
+    entity_data.ForgeData.enigmatica_equipment = true;
+    event.entity.fullNBT = entity_data;
 
     let mob_type = event.entity.type.split(':')[1];
     let mod_id = event.entity.type.split(':')[0];
@@ -64,7 +77,7 @@ EntityEvents.spawned((event) => {
                 event.entity.offHandItem = randomEnchant(equipment_set.offhand, enchant_level, use_treasure_enchants);
             }
             if (equipment_set.custom_name) {
-                let entity_data = event.entity.fullNBT;
+                entity_data = event.entity.fullNBT;
                 entity_data.CustomName = `{ "text" : "${equipment_set.custom_name}" }`;
                 event.entity.fullNBT = entity_data;
             }

--- a/kubejs/server_scripts/constants/armored_mobs.js
+++ b/kubejs/server_scripts/constants/armored_mobs.js
@@ -533,6 +533,7 @@ const armored_mobs = {
                 {
                     weight: 25,
                     set: {
+                        max_health: 40,
                         effects: [
                             { type: 'minecraft:strength', amplifier: 2 },
                             { type: 'minecraft:resistance', amplifier: 1 }
@@ -568,8 +569,8 @@ const armored_mobs = {
                 {
                     weight: 10,
                     set: {
+                        max_health: 50,
                         effects: [
-                            { type: 'minecraft:strength', amplifier: 3 },
                             { type: 'minecraft:resistance', amplifier: 2 },
                             { type: 'minecraft:absorption', amplifier: 2 },
                             { type: 'ars_nouveau:shielding', amplifier: 2 }


### PR DESCRIPTION
Script was running again if the mob was picked up and put back down with a soul gem. 