### PR TITLE
Give Archdruids some poison spray

### DIFF
--- a/kubejs/server_scripts/constants/armored_mobs.js
+++ b/kubejs/server_scripts/constants/armored_mobs.js
@@ -587,8 +587,8 @@ const armored_mobs = {
                         ),
                         chest: Item.of(
                             'twilightforest:steeleaf_chestplate',
-                            '{"quark:RuneAttached":1b,"quark:RuneColor":{Count:1b,id:"quark:green_rune"}}'
-                        ),
+                            '{"ars_nouveau:reactive_caster":{current_slot:0,flavor:"",spell_count:1,spells:{spell0:{name:"Poison Globule",recipe:{part0:"ars_elemental:glyph_curved_projectile",part1:"ars_nouveau:glyph_pierce",part2:"ars_nouveau:glyph_pierce",part3:"ars_nouveau:glyph_linger",part4:"ars_nouveau:glyph_harm",part5:"ars_nouveau:glyph_extend_time",part6:"ars_nouveau:glyph_hex",part7:"ars_elemental:glyph_poison_spores",part8:"ars_nouveau:glyph_extend_time",part9:"ars_nouveau:glyph_amplify",size:10},sound:{pitch:1.0f,soundTag:{id:"ars_nouveau:fire_family"},volume:1.0f},spellColor:{b:25,g:255,r:25}}}},"quark:RuneAttached":1b,"quark:RuneColor":{Count:1b,id:"quark:green_rune"}}'
+                        ).enchant('ars_nouveau:reactive', 3),
                         legs: Item.of(
                             'twilightforest:steeleaf_leggings',
                             '{"quark:RuneAttached":1b,"quark:RuneColor":{Count:1b,id:"quark:green_rune"}}'


### PR DESCRIPTION
Arch Druids (rare subtype of Twilight Forest Skeleton Druids) now have a chance to proc a reactive poison cloud when struck. 