### PR TITLE
[Expert] Disable Mending and Ingot drops from mobs

### DIFF
--- a/config/configswapper/expert/config/quark-common.toml
+++ b/config/configswapper/expert/config/quark-common.toml
@@ -1328,11 +1328,11 @@
 		#Resets all villager discounts when zombified to prevent reducing prices to ridiculous levels
 		"Nerf Villager Discount" = true
 		#Makes Iron Golems not drop Iron Ingots
-		"Disable Iron Farms" = true
+		"Disable Iron Farms" = false
 		#Makes Boats not glide on ice
 		"Disable Ice Roads" = false
 		#Makes Sheep not drop Wool when killed
-		"Disable Wool Drops" = true
+		"Disable Wool Drops" = false
 
 	[experimental.enchantments_begone]
 		"Enchantments To Begone" = [
@@ -1342,7 +1342,8 @@
 			"minecraft:respiration",
 			"minecraft:binding_curse",
 			"minecraft:vanishing_curse",
-			"supplementaries:stasis"
+			"supplementaries:stasis",
+			"minecraft:mending"
 		]
 
 	[experimental.adjustable_chat]

--- a/kubejs/server_scripts/base/entity/spawned/equipment.js
+++ b/kubejs/server_scripts/base/entity/spawned/equipment.js
@@ -53,6 +53,7 @@ EntityEvents.spawned((event) => {
     let use_treasure_enchants = false;
     if (equipment_set.enchant) {
         // Sets the enchantment level to a random integer between two values. Defaults to 0 (disabled) if not specified in 'armored_mobs' constant
+
         if (Math.random() < equipment_set.enchant.chance) {
             enchant_level = randomInt(equipment_set.enchant.level.min, equipment_set.enchant.level.max);
         }

--- a/kubejs/server_scripts/base/entity/spawned/equipment.js
+++ b/kubejs/server_scripts/base/entity/spawned/equipment.js
@@ -56,6 +56,7 @@ EntityEvents.spawned((event) => {
         if (Math.random() < equipment_set.enchant.chance) {
             enchant_level = randomInt(equipment_set.enchant.level.min, equipment_set.enchant.level.max);
         }
+
         // Allow treasure enchants, such as Mending, to appear on the equipment
         // Default to false if not specified in 'armored_mobs' constant
         if (equipment_set.enchant.treasure) {

--- a/kubejs/server_scripts/base/loot_tables/entities/twilightforest/death_tome.js
+++ b/kubejs/server_scripts/base/loot_tables/entities/twilightforest/death_tome.js
@@ -1,55 +1,49 @@
 ServerEvents.entityLootTables((event) => {
-    const tables = [
-        {
-            rolls: [1, 3],
-            loot_conditions: [
-                { condition: 'minecraft:killed_by_player' },
-                {
-                    chance: 0.25,
-                    condition: 'minecraft:random_chance_with_looting',
-                    looting_multiplier: 0.05
-                }
-            ],
-            loot_items: [
-                { item: 'ars_nouveau:glyph_rune', weight: 1 },
-                { item: 'ars_nouveau:glyph_redstone_signal', weight: 1 },
-                { item: 'ars_nouveau:glyph_touch', weight: 1 },
-                { item: 'ars_nouveau:glyph_evaporate', weight: 1 },
-                { item: 'ars_nouveau:glyph_sensitive', weight: 1 },
-                { item: 'ars_nouveau:glyph_break', weight: 1 },
-                { item: 'ars_nouveau:glyph_dispel', weight: 1 },
-                { item: 'ars_nouveau:glyph_self', weight: 1 },
-                { item: 'ars_nouveau:glyph_leap', weight: 1 },
-                { item: 'ars_nouveau:glyph_snare', weight: 1 },
-                { item: 'ars_nouveau:glyph_summon_wolves', weight: 1 },
-                { item: 'ars_nouveau:glyph_bounce', weight: 1 },
-                { item: 'ars_nouveau:glyph_summon_steed', weight: 1 },
-                { item: 'ars_nouveau:glyph_light', weight: 1 },
-                { item: 'ars_nouveau:glyph_underfoot', weight: 1 },
-                { item: 'ars_nouveau:glyph_freeze', weight: 1 },
-                { item: 'ars_nouveau:glyph_amplify', weight: 1 },
-                { item: 'ars_nouveau:glyph_cut', weight: 1 },
-                { item: 'ars_nouveau:glyph_aquatic', weight: 1 },
-                { item: 'ars_nouveau:glyph_harm', weight: 1 },
-                { item: 'ars_nouveau:glyph_gust', weight: 1 },
-                { item: 'ars_nouveau:glyph_projectile', weight: 1 },
-                { item: 'ars_nouveau:glyph_delay', weight: 1 },
-                { item: 'ars_nouveau:glyph_harvest', weight: 1 },
-                { item: 'ars_nouveau:glyph_ignite', weight: 1 },
-                { item: 'ars_nouveau:glyph_toss', weight: 1 },
-                { item: 'ars_nouveau:glyph_phantom_block', weight: 1 },
-                { item: 'ars_nouveau:glyph_launch', weight: 1 },
-                { item: 'ars_nouveau:glyph_place_block', weight: 1 },
-                { item: 'ars_nouveau:glyph_pull', weight: 1 },
-                { item: 'ars_nouveau:glyph_craft', weight: 1 },
-                { item: 'ars_nouveau:glyph_interact', weight: 1 },
-                { item: 'ars_nouveau:glyph_pickup', weight: 1 },
-                { item: 'ars_elemental:glyph_conjure_terrain', weight: 1 }
-            ]
-        }
-    ];
+    // Add to Death Tome Loot Table
+    event.modifyEntity('twilightforest:death_tome', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({ condition: 'minecraft:killed_by_player' });
+            pool.addCondition({
+                chance: 0.25,
+                condition: 'minecraft:random_chance_with_looting',
+                looting_multiplier: 0.05
+            });
 
-    tables.forEach((table) => {
-        modifyEntityLootTable(event, 'twilightforest:death_tome', table);
+            pool.addItem('ars_nouveau:glyph_rune', 1);
+            pool.addItem('ars_nouveau:glyph_redstone_signal', 1);
+            pool.addItem('ars_nouveau:glyph_touch', 1);
+            pool.addItem('ars_nouveau:glyph_evaporate', 1);
+            pool.addItem('ars_nouveau:glyph_sensitive', 1);
+            pool.addItem('ars_nouveau:glyph_break', 1);
+            pool.addItem('ars_nouveau:glyph_dispel', 1);
+            pool.addItem('ars_nouveau:glyph_self', 1);
+            pool.addItem('ars_nouveau:glyph_leap', 1);
+            pool.addItem('ars_nouveau:glyph_snare', 1);
+            pool.addItem('ars_nouveau:glyph_summon_wolves', 1);
+            pool.addItem('ars_nouveau:glyph_bounce', 1);
+            pool.addItem('ars_nouveau:glyph_summon_steed', 1);
+            pool.addItem('ars_nouveau:glyph_light', 1);
+            pool.addItem('ars_nouveau:glyph_underfoot', 1);
+            pool.addItem('ars_nouveau:glyph_freeze', 1);
+            pool.addItem('ars_nouveau:glyph_amplify', 1);
+            pool.addItem('ars_nouveau:glyph_cut', 1);
+            pool.addItem('ars_nouveau:glyph_aquatic', 1);
+            pool.addItem('ars_nouveau:glyph_harm', 1);
+            pool.addItem('ars_nouveau:glyph_gust', 1);
+            pool.addItem('ars_nouveau:glyph_projectile', 1);
+            pool.addItem('ars_nouveau:glyph_delay', 1);
+            pool.addItem('ars_nouveau:glyph_harvest', 1);
+            pool.addItem('ars_nouveau:glyph_ignite', 1);
+            pool.addItem('ars_nouveau:glyph_toss', 1);
+            pool.addItem('ars_nouveau:glyph_phantom_block', 1);
+            pool.addItem('ars_nouveau:glyph_launch', 1);
+            pool.addItem('ars_nouveau:glyph_place_block', 1);
+            pool.addItem('ars_nouveau:glyph_pull', 1);
+            pool.addItem('ars_nouveau:glyph_craft', 1);
+            pool.addItem('ars_nouveau:glyph_interact', 1);
+            pool.addItem('ars_nouveau:glyph_pickup', 1);
+            pool.addItem('ars_elemental:glyph_conjure_terrain', 1);
+        });
     });
 });

--- a/kubejs/server_scripts/constants/armored_mobs.js
+++ b/kubejs/server_scripts/constants/armored_mobs.js
@@ -545,7 +545,7 @@ const armored_mobs = {
                         effects: [{ type: 'minecraft:resistance', amplifier: 1 }],
                         max_health: 40,
                         enchant: {
-                            chance: 0.5,
+                            chance: 1.0,
                             level: { min: 10, max: 20 },
                             treasure: false
                         },

--- a/kubejs/server_scripts/expert/loot_tables/entities/minecraft/drowned.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/minecraft/drowned.js
@@ -1,0 +1,43 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Drowned Loot Table
+    event.addEntity('minecraft:drowned', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:rotten_flesh', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({ condition: 'minecraft:killed_by_player' });
+            pool.addCondition({
+                chance: 0.025,
+                condition: 'minecraft:random_chance_with_looting',
+                looting_multiplier: 0.01
+            });
+
+            pool.addItem('minecraft:sea_pickle', 1);
+            pool.addItem('minecraft:scute', 1);
+            pool.addItem('minecraft:kelp', 1).addFunction({
+                function: 'minecraft:furnace_smelt',
+                conditions: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        entity: 'this',
+                        predicate: { flags: { is_on_fire: true } }
+                    }
+                ]
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/minecraft/husk.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/minecraft/husk.js
@@ -1,0 +1,43 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Husk Loot Table
+    event.addEntity('minecraft:husk', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:rotten_flesh', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({ condition: 'minecraft:killed_by_player' });
+            pool.addCondition({
+                chance: 0.025,
+                condition: 'minecraft:random_chance_with_looting',
+                looting_multiplier: 0.01
+            });
+
+            pool.addItem('supplementaries:flax', 1);
+            pool.addItem('minecraft:cactus', 1);
+            pool.addItem('byg:joshua_fruit', 1).addFunction({
+                function: 'minecraft:furnace_smelt',
+                conditions: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        entity: 'this',
+                        predicate: { flags: { is_on_fire: true } }
+                    }
+                ]
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/minecraft/iron_golem.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/minecraft/iron_golem.js
@@ -1,0 +1,29 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Iron Golem Loot Table
+    event.addEntity('minecraft:iron_golem', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:poppy', 1).addFunction({
+                function: 'minecraft:set_count',
+                count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                add: false
+            });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('quark:rusty_iron_plate', 3).addFunction({
+                function: 'minecraft:set_count',
+                count: { type: 'minecraft:uniform', max: 4.0, min: 2.0 },
+                add: false
+            });
+            pool.addItem('quark:iron_plate', 1).addFunction({
+                function: 'minecraft:set_count',
+                count: { type: 'minecraft:uniform', max: 4.0, min: 2.0 },
+                add: false
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/minecraft/zombie.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/minecraft/zombie.js
@@ -1,0 +1,45 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Zombie Loot Table
+    event.addEntity('minecraft:zombie', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:rotten_flesh', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({ condition: 'minecraft:killed_by_player' });
+            pool.addCondition({
+                chance: 0.025,
+                condition: 'minecraft:random_chance_with_looting',
+                looting_multiplier: 0.01
+            });
+
+            pool.addItem('minecraft:carrot', 1);
+            pool.addItem('farmersdelight:onion', 1);
+            pool.addItem('farmersdelight:brown_mushroom_colony', 1);
+            pool.addItem('farmersdelight:red_mushroom_colony', 1);
+            pool.addItem('minecraft:potato', 1).addFunction({
+                function: 'minecraft:furnace_smelt',
+                conditions: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        entity: 'this',
+                        predicate: { flags: { is_on_fire: true } }
+                    }
+                ]
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/minecraft/zombie_villager.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/minecraft/zombie_villager.js
@@ -1,0 +1,45 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Zombie Villager Loot Table
+    event.addEntity('minecraft:zombie_villager', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:rotten_flesh', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({ condition: 'minecraft:killed_by_player' });
+            pool.addCondition({
+                chance: 0.025,
+                condition: 'minecraft:random_chance_with_looting',
+                looting_multiplier: 0.01
+            });
+
+            pool.addItem('minecraft:carrot', 1);
+            pool.addItem('farmersdelight:onion', 1);
+            pool.addItem('farmersdelight:brown_mushroom_colony', 1);
+            pool.addItem('farmersdelight:red_mushroom_colony', 1);
+            pool.addItem('minecraft:potato', 1).addFunction({
+                function: 'minecraft:furnace_smelt',
+                conditions: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        entity: 'this',
+                        predicate: { flags: { is_on_fire: true } }
+                    }
+                ]
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/minecraft/zombified_piglin.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/minecraft/zombified_piglin.js
@@ -1,0 +1,40 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Zombified Piglin Loot Table
+    event.addEntity('minecraft:zombified_piglin', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:rotten_flesh', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({ condition: 'minecraft:killed_by_player' });
+            pool.addCondition({
+                condition: 'minecraft:random_chance_with_looting',
+                chance: 0.015,
+                looting_multiplier: 0.01
+            });
+            pool.addItem('minecraft:golden_apple', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/carminite_golem.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/carminite_golem.js
@@ -1,0 +1,29 @@
+ServerEvents.entityLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Carminite Golem Loot Table
+    event.addEntity('twilightforest:carminite_golem', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('twilightforest:towerwood', 1).addFunction({
+                function: 'minecraft:set_count',
+                count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                add: false
+            });
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('quark:rusty_iron_plate', 3).addFunction({
+                function: 'minecraft:set_count',
+                count: { type: 'minecraft:uniform', max: 4.0, min: 2.0 },
+                add: false
+            });
+            pool.addItem('quark:iron_plate', 1).addFunction({
+                function: 'minecraft:set_count',
+                count: { type: 'minecraft:uniform', max: 4.0, min: 2.0 },
+                add: false
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/kobold.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/kobold.js
@@ -2,11 +2,11 @@ ServerEvents.entityLootTables((event) => {
     if (global.isExpertMode == false) {
         return;
     }
-    // Override Husk Loot Table
-    event.addEntity('minecraft:husk', (table) => {
+    // Override Kobold Loot Table
+    event.addEntity('twilightforest:kobold', (table) => {
         table.addPool((pool) => {
             pool.rolls = 1.0;
-            pool.addItem('minecraft:rotten_flesh', 1)
+            pool.addItem('minecraft:wheat', 1)
                 .addFunction({
                     function: 'minecraft:set_count',
                     count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
@@ -22,22 +22,20 @@ ServerEvents.entityLootTables((event) => {
             pool.addCondition({ condition: 'minecraft:killed_by_player' });
             pool.addCondition({
                 condition: 'minecraft:random_chance_with_looting',
-                chance: 0.025,
-                looting_multiplier: 0.01
+                chance: 0.075,
+                looting_multiplier: 0.02
             });
 
-            pool.addItem('supplementaries:flax', 1);
-            pool.addItem('minecraft:cactus', 1);
-            pool.addItem('byg:joshua_fruit', 1).addFunction({
-                function: 'minecraft:furnace_smelt',
-                conditions: [
-                    {
-                        condition: 'minecraft:entity_properties',
-                        entity: 'this',
-                        predicate: { flags: { is_on_fire: true } }
-                    }
-                ]
-            });
+            pool.addItem('minecraft:prismarine_crystals', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', max: 2.0, min: 0.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', max: 1.0, min: 0.0 }
+                });
         });
     });
 });

--- a/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/questing_ram_rewards.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/questing_ram_rewards.js
@@ -1,0 +1,20 @@
+ServerEvents.genericLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Questing Ram Rewards Loot Table
+    event.addGeneric('twilightforest:entities/questing_ram_rewards', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('twilightforest:crumble_horn', 1);
+        });
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:bundle', 1).addFunction({
+                function: 'minecraft:set_nbt',
+                tag: '{Items:[{Count:1b,id:"twilightforest:quest_ram_trophy"},{Count:1b,id:"minecraft:coal_block"},{Count:1b,id:"minecraft:prismarine_bricks"},{Count:1b,id:"minecraft:lapis_block"}]}'
+                // TODO: This is really boring. Find some fun things to stick in here in the future.
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/functions.js
+++ b/kubejs/server_scripts/functions.js
@@ -66,11 +66,11 @@ const playerHas = (item, player) => {
 const randomEnchant = (item, level, treasure) => {
     if (level == 0) {
         return Item.of(item);
+    } else {
+        let EnchantHelper = Java.loadClass('net.minecraft.world.item.enchantment.EnchantmentHelper');
+        let RandomSource = Java.loadClass('net.minecraft.util.RandomSource');
+        return EnchantHelper.enchantItem(RandomSource.create(), Item.of(item), level, treasure);
     }
-    let EnchantHelper = Java.loadClass('net.minecraft.world.item.enchantment.EnchantmentHelper');
-    let RandomSource = Java.loadClass('net.minecraft.util.RandomSource');
-    // return EnchantHelper.m_220292_(RandomSource.m_216327_(), Item.of(item), level, treasure);
-    return EnchantHelper.enchantItem(RandomSource.create(), Item.of(item), level, treasure);
 };
 
 const randomInt = (min, max) => {
@@ -101,71 +101,6 @@ function randomFloat(number, offset) {
     let max = number + offset;
 
     return Math.random() * (max - min + 1) + min;
-}
-
-function generatePool(table, loot_table) {
-    // For help setting up conditions, functions, and non item entries: https://amaury.carrade.eu/minecraft/loot_tables
-    // Minecraft wiki also has great information on how these work
-    table.addPool((pool) => {
-        pool.rolls = pool.rolls ? loot_table.rolls : 1;
-
-        // For special conditions
-        if (loot_table.loot_conditions) {
-            loot_table.loot_conditions.forEach((loot_condition) => {
-                pool.addCondition(loot_condition);
-            });
-        }
-
-        // For special functions
-        if (loot_table.loot_functions) {
-            loot_table.loot_functions.forEach((loot_function) => {
-                pool.addFunction(loot_function);
-            });
-        }
-
-        // For external loot tables
-        if (loot_table.loot_entries) {
-            loot_table.loot_entries.forEach((loot_entry) => {
-                pool.addEntry(loot_entry);
-            });
-        }
-
-        if (loot_table.loot_items) {
-            loot_table.loot_items.forEach((loot_item) => {
-                pool.addItem(Item.of(loot_item.item), loot_item.weight);
-            });
-        }
-
-        if (loot_table.generic_entries) {
-            loot_table.generic_entries.forEach((generic_entry) => {
-                pool.addEntry(generic_entry);
-            });
-        }
-    });
-}
-
-function addEntityLootTable(event, entity, loot_table) {
-    event.addEntity(entity, (table) => {
-        generatePool(table, loot_table);
-    });
-}
-
-function modifyEntityLootTable(event, entity, loot_table) {
-    event.modifyEntity(entity, (table) => {
-        generatePool(table, loot_table);
-    });
-}
-
-function modifyLootTable(event, loot_id, loot_table) {
-    event.modify(loot_id, (table) => {
-        generatePool(table, loot_table);
-    });
-}
-
-function addLootTable(event, loot_id, loot_table) {
-    event.add(loot_id, (table) => {
-        generatePool(table, loot_table);
-    });
 }
 
 function generatePentacleEntry(ritual_name, x_placement, y_placement) {

--- a/kubejs/server_scripts/functions.js
+++ b/kubejs/server_scripts/functions.js
@@ -84,7 +84,7 @@ function randomEnchant(item, level, treasure) {
 
     let enchantedItem = Item.of(item);
     enchants.forEach((enchant) => {
-        enchantedItem.enchant(enchant.enchantment, enchant.level);
+        enchantedItem = Item.of(enchantedItem).enchant(enchant.enchantment, enchant.level);
     });
 
     return enchantedItem;

--- a/kubejs/server_scripts/functions.js
+++ b/kubejs/server_scripts/functions.js
@@ -63,19 +63,36 @@ const playerHas = (item, player) => {
     return player.inventory.find(item) != -1;
 };
 
-const randomEnchant = (item, level, treasure) => {
+const RandomSource = Java.loadClass('net.minecraft.util.RandomSource');
+const RealEnchantHelper = Java.loadClass('shadows.apotheosis.ench.table.RealEnchantmentHelper');
+
+function randomEnchant(item, level, treasure) {
     if (level == 0) {
         return Item.of(item);
-    } else {
-        let EnchantHelper = Java.loadClass('net.minecraft.world.item.enchantment.EnchantmentHelper');
-        let RandomSource = Java.loadClass('net.minecraft.util.RandomSource');
-        return EnchantHelper.enchantItem(RandomSource.create(), Item.of(item), level, treasure);
     }
-};
 
-const randomInt = (min, max) => {
+    // shadows.apotheosis.ench.table.RealEnchantmentHelper.selectEnchantment(RandomSource rand, ItemStack stack, int level, float quanta, float arcana, float rectification, boolean treasure)
+    let enchants = RealEnchantHelper.selectEnchantment(
+        RandomSource.create(),
+        Item.of(item),
+        level,
+        30.0,
+        0.0,
+        0.0,
+        treasure
+    );
+
+    let enchantedItem = Item.of(item);
+    enchants.forEach((enchant) => {
+        enchantedItem.enchant(enchant.enchantment, enchant.level);
+    });
+
+    return enchantedItem;
+}
+
+function randomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1) + min);
-};
+}
 
 function weightedEquipment(options) {
     let i;


### PR DESCRIPTION
Disables ingots dropping from any mobs. (Vanilla mobs done, need to check other mods)

Disables Mending entirely. Between Life Mending and Aura Mend, I think those cover things pretty well. Eventually Botania (and Botania Additions) will also allow repairing anything with Mana. 