### PR TITLE
Adjust Cave Creeper and Stoneling Loot Tables

### DIFF
--- a/kubejs/server_scripts/base/loot_tables/entities/creeperoverhaul/cave_creeper.js
+++ b/kubejs/server_scripts/base/loot_tables/entities/creeperoverhaul/cave_creeper.js
@@ -1,0 +1,57 @@
+ServerEvents.entityLootTables((event) => {
+    // Override Cave Creeper Loot Table
+    event.addEntity('creeperoverhaul:cave_creeper', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:gunpowder', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', min: 0.0, max: 2.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', min: 0.0, max: 1.0 }
+                });
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:stone', 1)
+                .addFunction({
+                    function: 'minecraft:set_count',
+                    count: { type: 'minecraft:uniform', min: 0.0, max: 2.0 },
+                    add: false
+                })
+                .addFunction({
+                    function: 'minecraft:looting_enchant',
+                    count: { type: 'minecraft:uniform', min: 0.0, max: 1.0 }
+                });
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('minecraft:glow_lichen', 1)
+                .addCondition({ condition: 'minecraft:killed_by_player' })
+                .addCondition({
+                    condition: 'minecraft:random_chance_with_looting',
+                    chance: 0.2,
+                    looting_multiplier: 0.02
+                });
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addCondition({
+                condition: 'minecraft:entity_properties',
+                predicate: { type: '#minecraft:skeletons' },
+                entity: 'killer'
+            });
+            pool.addEntry({
+                type: 'minecraft:tag',
+                name: 'minecraft:creeper_drop_music_discs',
+                expand: true
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/base/loot_tables/entities/quark/stoneling_carry.js
+++ b/kubejs/server_scripts/base/loot_tables/entities/quark/stoneling_carry.js
@@ -1,0 +1,33 @@
+ServerEvents.genericLootTables((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    // Override Stoneling Carry Loot Table
+    event.addGeneric('quark:entities/stoneling_carry', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addItem('supplementaries:rope_arrow', 200);
+            pool.addItem('minecraft:redstone', 300, [10, 15]);
+            pool.addItem('minecraft:emerald', 200, [1, 3]);
+            pool.addItem('minecraft:zombie_head', 250);
+            pool.addItem('minecraft:creeper_head', 250);
+            pool.addItem('minecraft:lapis_lazuli', 200, [4, 8]);
+            pool.addItem('minecraft:golden_apple', 50);
+            pool.addItem('minecraft:saddle', 50);
+            pool.addItem('minecraft:iron_horse_armor', 50);
+            pool.addItem('minecraft:golden_horse_armor', 40);
+            pool.addItem('minecraft:diamond_horse_armor', 30);
+            pool.addItem('minecraft:name_tag', 100);
+
+            pool.addItem('quark:black_corundum', 100);
+            pool.addItem('quark:white_corundum', 100);
+            pool.addItem('quark:violet_corundum', 100);
+            pool.addItem('quark:indigo_corundum', 100);
+            pool.addItem('quark:blue_corundum', 100);
+            pool.addItem('quark:green_corundum', 100);
+            pool.addItem('quark:yellow_corundum', 100);
+            pool.addItem('quark:orange_corundum', 100);
+            pool.addItem('quark:red_corundum', 100);
+        });
+    });
+});


### PR DESCRIPTION
Default Stonelings are basically an all in one mob farm, dropping diamonds, emeralds, gold, iron, and more... Changed to make them a little less crazy.

Remove ore drops from Cave Creepers, replacing it with a small chance for glow lichen instead. 