### PR TITLE
Reinstate Dye Mixing Recipes

### DIFF
--- a/kubejs/server_scripts/base/recipes/ars_nouveau/shapeless.js
+++ b/kubejs/server_scripts/base/recipes/ars_nouveau/shapeless.js
@@ -1,0 +1,15 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/ars_nouveau/shapeless/';
+
+    const recipes = [
+        {
+            output: Item.of('ars_nouveau:magebloom_fiber', 12),
+            inputs: ['ars_nouveau:magebloom', 'ars_nouveau:magebloom', 'ars_nouveau:magebloom'],
+            id: 'ars_nouveau:magebloom_fiber'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/enigmatica/dye_crushing.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/dye_crushing.js
@@ -6,7 +6,8 @@ ServerEvents.recipes((event) => {
     colors.forEach((color) => {
         ['large', 'small'].forEach((input_size) => {
             let input = `#enigmatica:${input_size}_dye_sources/${color}`;
-            if (Ingredient.of(input).stacks.isEmpty()) {
+
+            if (getItemsInTag(input).includes('minecraft:barrier')) {
                 return;
             }
             let output = `minecraft:${color}_dye`;

--- a/kubejs/server_scripts/base/recipes/enigmatica/shapeless.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/shapeless.js
@@ -1,7 +1,78 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/enigmatica/shapeless/';
 
-    const recipes = [];
+    const recipes = [
+        {
+            output: Item.of('minecraft:orange_dye', 2),
+            inputs: ['#forge:dyes/red', '#forge:dyes/yellow'],
+            id: `${id_prefix}orange_dye_from_red_yellow`
+        },
+        {
+            output: Item.of('minecraft:magenta_dye', 2),
+            inputs: ['#forge:dyes/purple', '#forge:dyes/pink'],
+            id: `${id_prefix}magenta_dye_from_purple_pink`
+        },
+        {
+            output: Item.of('minecraft:magenta_dye', 3),
+            inputs: ['#forge:dyes/blue', '#forge:dyes/red', '#forge:dyes/pink'],
+            id: `${id_prefix}magenta_dye_from_blue_red_pink`
+        },
+        {
+            output: Item.of('minecraft:magenta_dye', 4),
+            inputs: ['#forge:dyes/blue', '#forge:dyes/red', '#forge:dyes/pink'],
+            id: `${id_prefix}magenta_dye_from_blue_red_white`
+        },
+        {
+            output: Item.of('minecraft:light_blue_dye', 2),
+            inputs: ['#forge:dyes/blue', '#forge:dyes/white'],
+            id: `${id_prefix}light_blue_dye_from_blue_white`
+        },
+        {
+            output: Item.of('minecraft:lime_dye', 2),
+            inputs: ['#forge:dyes/green', '#forge:dyes/white'],
+            id: `${id_prefix}lime_dye_from_green_white`
+        },
+        {
+            output: Item.of('minecraft:pink_dye', 2),
+            inputs: ['#forge:dyes/red', '#forge:dyes/white'],
+            id: `${id_prefix}pink_dye_from_red_white`
+        },
+        {
+            output: Item.of('minecraft:gray_dye', 2),
+            inputs: ['#forge:dyes/black', '#forge:dyes/white'],
+            id: `${id_prefix}gray_dye_from_black_white`
+        },
+        {
+            output: Item.of('minecraft:light_gray_dye', 2),
+            inputs: ['#forge:dyes/gray', '#forge:dyes/white'],
+            id: `${id_prefix}light_gray_dye_from_gray_white`
+        },
+        {
+            output: Item.of('minecraft:light_gray_dye', 3),
+            inputs: ['#forge:dyes/black', '#forge:dyes/white', '#forge:dyes/white'],
+            id: `${id_prefix}light_gray_dye_from_black_white`
+        },
+        {
+            output: Item.of('minecraft:cyan_dye', 2),
+            inputs: ['#forge:dyes/blue', '#forge:dyes/green'],
+            id: `${id_prefix}cyan_dye_from_blue_green`
+        },
+        {
+            output: Item.of('minecraft:purple_dye', 2),
+            inputs: ['#forge:dyes/blue', '#forge:dyes/red'],
+            id: `${id_prefix}purple_dye_from_blue_red`
+        },
+        {
+            output: Item.of('minecraft:brown_dye', 2),
+            inputs: ['#forge:dyes/green', '#forge:dyes/red'],
+            id: `${id_prefix}brown_dye_from_green_red`
+        },
+        {
+            output: Item.of('minecraft:green_dye', 2),
+            inputs: ['#forge:dyes/blue', '#forge:dyes/yellow'],
+            id: `${id_prefix}green_dye_from_blue_yellow`
+        }
+    ];
 
     recipes.forEach((recipe) => {
         event.shapeless(recipe.output, recipe.inputs).id(recipe.id);

--- a/kubejs/server_scripts/base/tags/items/forge/dyes.js
+++ b/kubejs/server_scripts/base/tags/items/forge/dyes.js
@@ -1,0 +1,4 @@
+ServerEvents.tags('item', (event) => {
+    event.get('forge:dyes').remove(['mekanism:dust_sulfur']);
+    event.get('forge:dyes/yellow').remove(['mekanism:dust_sulfur']);
+});

--- a/kubejs/server_scripts/constants/dye_sources.js
+++ b/kubejs/server_scripts/constants/dye_sources.js
@@ -46,6 +46,13 @@ const dye_sources = [
         tertiary: 'minecraft:black_dye'
     },
     {
+        input: 'minecraft:glow_ink_sac',
+        type: 'small',
+        primary: 'minecraft:cyan_dye',
+        secondary: 'minecraft:green_dye',
+        tertiary: 'minecraft:glowstone_dust'
+    },
+    {
         input: 'minecraft:charcoal',
         type: 'small',
         primary: 'minecraft:black_dye',
@@ -261,6 +268,20 @@ const dye_sources = [
         primary: 'minecraft:black_dye',
         secondary: 'minecraft:black_dye',
         tertiary: 'minecraft:gray_dye'
+    },
+    {
+        input: 'minecraft:sweet_berries',
+        type: 'small',
+        primary: 'minecraft:red_dye',
+        secondary: 'minecraft:red_dye',
+        tertiary: 'minecraft:red_dye'
+    },
+    {
+        input: 'minecraft:glow_berries',
+        type: 'small',
+        primary: 'minecraft:orange_dye',
+        secondary: 'minecraft:orange_dye',
+        tertiary: 'minecraft:yellow_dye'
     },
     // Farmer's Delight
 
@@ -748,6 +769,20 @@ const dye_sources = [
         secondary: 'minecraft:yellow_dye',
         tertiary: 'minecraft:lime_dye'
     },
+    {
+        input: 'byg:nightshade_berries',
+        type: 'small',
+        primary: 'minecraft:yellow_dye',
+        secondary: 'minecraft:yellow_dye',
+        tertiary: 'minecraft:yellow_dye'
+    },
+    {
+        input: 'byg:crimson_berries',
+        type: 'small',
+        primary: 'minecraft:red_dye',
+        secondary: 'minecraft:red_dye',
+        tertiary: 'minecraft:orange_dye'
+    },
     // Blue Skies
     {
         input: 'blue_skies:camellia',
@@ -847,6 +882,27 @@ const dye_sources = [
         secondary: 'minecraft:light_gray_dye',
         tertiary: 'minecraft:purple_dye'
     },
+    {
+        input: 'blue_skies:brewberry',
+        type: 'small',
+        primary: 'minecraft:red_dye',
+        secondary: 'minecraft:red_dye',
+        tertiary: 'minecraft:red_dye'
+    },
+    {
+        input: 'blue_skies:pink_brewberry',
+        type: 'small',
+        primary: 'minecraft:pink_dye',
+        secondary: 'minecraft:pink_dye',
+        tertiary: 'minecraft:pink_dye'
+    },
+    {
+        input: 'blue_skies:black_brewberry',
+        type: 'small',
+        primary: 'minecraft:black_dye',
+        secondary: 'minecraft:black_dye',
+        tertiary: 'minecraft:purple_dye'
+    },
 
     // Twilight Forest
     {
@@ -863,7 +919,13 @@ const dye_sources = [
         secondary: 'minecraft:pink_dye',
         tertiary: 'minecraft:yellow_dye'
     },
-
+    {
+        input: 'twilightforest:torchberries',
+        type: 'small',
+        primary: 'minecraft:yellow_dye',
+        secondary: 'minecraft:yellow_dye',
+        tertiary: 'minecraft:glowstone_dust'
+    },
     // Book Wyrms
 
     {

--- a/kubejs/server_scripts/constants/dye_sources.js
+++ b/kubejs/server_scripts/constants/dye_sources.js
@@ -39,6 +39,20 @@ const dye_sources = [
         tertiary: 'minecraft:blue_dye'
     },
     {
+        input: 'minecraft:ink_sac',
+        type: 'small',
+        primary: 'minecraft:black_dye',
+        secondary: 'minecraft:black_dye',
+        tertiary: 'minecraft:black_dye'
+    },
+    {
+        input: 'minecraft:charcoal',
+        type: 'small',
+        primary: 'minecraft:black_dye',
+        secondary: 'minecraft:black_dye',
+        tertiary: 'minecraft:black_dye'
+    },
+    {
         input: 'minecraft:bone',
         type: 'small',
         primary: 'minecraft:bone_meal',
@@ -896,6 +910,23 @@ const dye_sources = [
     },
     {
         input: 'bookwyrms:scale_purple',
+        type: 'small',
+        primary: 'minecraft:purple_dye',
+        secondary: 'minecraft:purple_dye',
+        tertiary: 'minecraft:purple_dye'
+    },
+
+    // Ars Nouveau
+
+    {
+        input: 'ars_nouveau:magebloom',
+        type: 'small',
+        primary: 'minecraft:pink_dye',
+        secondary: 'minecraft:cyan_dye',
+        tertiary: 'minecraft:magenta_dye'
+    },
+    {
+        input: 'ars_nouveau:source_berry',
         type: 'small',
         primary: 'minecraft:purple_dye',
         secondary: 'minecraft:purple_dye',


### PR DESCRIPTION
Fixes issue with empty tags being used to create dye recipes. Not certain what is causing empty tags to have a `minecraft:barrier`, but it breaks the `.isEmpty()` check on Ingredients...

Also adds re-adds missing dye mixing recipes and adds some non vanilla ones (green and brown). Fixes #138