### PR TITLE
Mobs will spawn with custom random equipment again

### DIFF
--- a/kubejs/server_scripts/base/entity/spawned/equipment.js
+++ b/kubejs/server_scripts/base/entity/spawned/equipment.js
@@ -28,8 +28,8 @@ EntityEvents.spawned((event) => {
     event.entity.fullNBT = entity_data;
 
     // End if mob isn't in 'armored_mobs' constant
-    let mob_type = toString(event.entity.type).split(':')[1];
-    let mod_id = toString(event.entity.type).split(':')[0];
+    let mob_type = event.entity.type.split(':')[1];
+    let mod_id = event.entity.type.split(':')[0];
     if (!Object.keys(armored_mobs).includes(mod_id) || !Object.keys(armored_mobs[mod_id]).includes(mob_type)) {
         return;
     }


### PR DESCRIPTION
the `toString()` part of this didn't actually fix the issue, it just prevented the script from working.

KubeJS Forge 1902.6.0-build.128 fixed the underlying issue that had caused it to break in the first place. Spawns are now working again.