### PR TITLE
Fix Blue Skies Tool Box mechanic

### DIFF
--- a/kubejs/server_scripts/base/tags/items/blue_skies/ingots.js
+++ b/kubejs/server_scripts/base/tags/items/blue_skies/ingots.js
@@ -1,6 +1,6 @@
 ServerEvents.tags('item', (event) => {
     event.removeAll(`blue_skies:ingots`);
-    event.removeAll(`blue_skies:ingots/falsite`);
+    // event.removeAll(`blue_skies:ingots/falsite`);
     event.removeAll(`blue_skies:ingots/ventium`);
     event.removeAll(`blue_skies:ingots/horizonite`);
 });


### PR DESCRIPTION
`blue_skies:ingots/falsite` tag is required to apply falsite to tools to boost their durability