### PR TITLE
Allow Ars Nouveau's Amethyst Golems to harvest Certus Quartz

### DIFF
--- a/config/configswapper/expert/config/naturesaura-common.toml
+++ b/config/configswapper/expert/config/naturesaura-common.toml
@@ -1,12 +1,7 @@
 
 [general]
 	#Additional conversion recipes for the Botanist's Pickaxe right click function. Each entry needs to be formatted as modid:input_block[prop1=value1,...]->modid:output_block[prop1=value1,...] where block state properties are optional
-	additionalBotanistPickaxeConversions = [
-		"minecraft:farmland[moisture=0]->farmersdelight:rich_soil_farmland[moisture=0]",
-		"minecraft:farmland[moisture=7]->farmersdelight:rich_soil_farmland[moisture=7]",
-		"minecraft:stone->minecraft:moss_block",
-		"twilightforest:root->twilightforest:liveroot_block",
-	]
+	additionalBotanistPickaxeConversions = []
 	#Additional dimensions that map to Aura types that should be present in them. This is useful if you have a modpack with custom dimensions that should have Aura act similarly to an existing dimension in them. Each entry needs to be formatted as dimension_name->aura_type, where aura_type can be any of naturesaura:overworld, naturesaura:nether and naturesaura:end.
 	auraTypeOverrides = [
 		"blue_skies:everbright->naturesaura:nether",

--- a/config/configswapper/normal/config/naturesaura-common.toml
+++ b/config/configswapper/normal/config/naturesaura-common.toml
@@ -1,12 +1,7 @@
 
 [general]
 	#Additional conversion recipes for the Botanist's Pickaxe right click function. Each entry needs to be formatted as modid:input_block[prop1=value1,...]->modid:output_block[prop1=value1,...] where block state properties are optional
-	additionalBotanistPickaxeConversions = [
-		"minecraft:farmland[moisture=0]->farmersdelight:rich_soil_farmland[moisture=0]",
-		"minecraft:farmland[moisture=7]->farmersdelight:rich_soil_farmland[moisture=7]",
-		"minecraft:stone->minecraft:moss_block",
-		"twilightforest:root->twilightforest:liveroot_block",
-		]
+	additionalBotanistPickaxeConversions = []
 	#Additional dimensions that map to Aura types that should be present in them. This is useful if you have a modpack with custom dimensions that should have Aura act similarly to an existing dimension in them. Each entry needs to be formatted as dimension_name->aura_type, where aura_type can be any of naturesaura:overworld, naturesaura:nether and naturesaura:end.
 	auraTypeOverrides = [
 		"blue_skies:everbright->naturesaura:nether",

--- a/config/naturesaura-common.toml
+++ b/config/naturesaura-common.toml
@@ -1,7 +1,7 @@
 
 [general]
 	#Additional conversion recipes for the Botanist's Pickaxe right click function. Each entry needs to be formatted as modid:input_block[prop1=value1,...]->modid:output_block[prop1=value1,...] where block state properties are optional
-	additionalBotanistPickaxeConversions = ["minecraft:farmland[moisture=0]->farmersdelight:rich_soil_farmland[moisture=0]", "minecraft:farmland[moisture=7]->farmersdelight:rich_soil_farmland[moisture=7]", "minecraft:stone->minecraft:moss_block", "twilightforest:root->twilightforest:liveroot_block"]
+	additionalBotanistPickaxeConversions = []
 	#Additional projectile types that are allowed to be consumed by the projectile generator. Each entry needs to be formatted as entity_registry_name->aura_amount
 	additionalProjectiles = []
 	#The Aura to RF ratio used by the RF converter, read as aura*ratio = rf

--- a/kubejs/client_scripts/base/jei_descriptions.js
+++ b/kubejs/client_scripts/base/jei_descriptions.js
@@ -149,29 +149,6 @@ JEIEvents.information((event) => {
             text: ['Grows occasionally on Corundum Blocks when grown underground.']
         },
         {
-            items: ['naturesaura:infused_iron_pickaxe'],
-            text: [
-                'Right-Click Conversions:',
-                ' ',
-                'Cobblestone',
-                '⤷ Mossy Cobblestone',
-                'Stone Bricks',
-                '⤷ Mossy Stone Bricks',
-                'Cobblestone Wall',
-                '⤷ Mossy Cobblestone Wall',
-                ' ',
-                'Stone Brick Wall',
-                '⤷ Mossy Stone Brick Wall',
-                'Farmland',
-                '⤷ Rich Soil Farmland',
-                'Roots',
-                '⤷ Liveroots',
-                'Stone',
-                '⤷ Moss Block',
-                ' '
-            ]
-        },
-        {
             items: ['occultism:tallow'],
             text: [`The Butcher's Knife has been disabled. Craft tallow instead.`]
         },

--- a/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
+++ b/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
@@ -7,7 +7,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone`
         },
@@ -17,7 +17,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'farmersdelight:rich_soil_farmland' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 25 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/rich_soil_farmland`
         },
@@ -27,7 +27,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:moss_block' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/moss_block`
         },
@@ -37,7 +37,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'twilightforest:liveroot_block' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 125 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/liveroot_block`
         },
@@ -47,7 +47,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_bricks' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_bricks`
         },
@@ -57,7 +57,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_wall' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_wall`
         },
@@ -67,7 +67,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_stairs' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_stairs`
         },
@@ -77,7 +77,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_stairs' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_stairs`
         },
@@ -87,7 +87,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_slab' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_slab`
         },
@@ -97,7 +97,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_wall' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 50 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_wall`
         },
@@ -107,7 +107,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:damaged_budding_quartz' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 200 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/damaged_budding_quartz`
         },
@@ -117,7 +117,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:chipped_budding_quartz' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 200 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/chipped_budding_quartz`
         },
@@ -127,7 +127,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawed_budding_quartz' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 200 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawed_budding_quartz`
         },
@@ -137,7 +137,7 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawless_budding_quartz' },
-                { type: 'damage_item', damage: 100 }
+                { type: 'damage_item', damage: 200 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawless_budding_quartz`
         }

--- a/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
+++ b/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
@@ -14,7 +14,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone`
         },
@@ -25,7 +25,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'farmersdelight:rich_soil_farmland' },
                 { type: 'damage_item', damage: 25 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/rich_soil_farmland`
         },
@@ -36,7 +36,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:moss_block' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/moss_block`
         },
@@ -47,7 +47,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'twilightforest:liveroot_block' },
                 { type: 'damage_item', damage: 125 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/liveroot_block`
         },
@@ -58,7 +58,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_bricks' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_bricks`
         },
@@ -69,7 +69,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_wall' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_wall`
         },
@@ -80,7 +80,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_stairs' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_stairs`
         },
@@ -91,7 +91,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_stairs' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_stairs`
         },
@@ -102,7 +102,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_slab' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_slab`
         },
@@ -113,7 +113,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_wall' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_wall`
         },
@@ -124,7 +124,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:damaged_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/damaged_budding_quartz`
         },
@@ -135,7 +135,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:chipped_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/chipped_budding_quartz`
         },
@@ -146,7 +146,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawed_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawed_budding_quartz`
         },
@@ -157,7 +157,7 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawless_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 5 }
+                { type: 'add_item_cooldown', s: 2 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawless_budding_quartz`
         }

--- a/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
+++ b/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
@@ -1,11 +1,6 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/lychee/block_interacting/';
 
-    // Todo: Add sound effects to these with https://lycheetweaker.readthedocs.io/en/latest/post-action/#execute-command-execute
-    // https://www.digminecraft.com/game_commands/playsound_command.php
-
-    // Stone sound: block.stone.place
-    // certus sound:
     const recipes = [
         {
             item_in: { item: 'naturesaura:infused_iron_pickaxe' },
@@ -14,7 +9,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone`
         },
@@ -25,7 +25,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'farmersdelight:rich_soil_farmland' },
                 { type: 'damage_item', damage: 25 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.grass.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/rich_soil_farmland`
         },
@@ -36,7 +41,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:moss_block' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/moss_block`
         },
@@ -47,7 +57,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'twilightforest:liveroot_block' },
                 { type: 'damage_item', damage: 125 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.grass.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/liveroot_block`
         },
@@ -58,7 +73,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_bricks' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_bricks`
         },
@@ -69,7 +89,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_wall' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_wall`
         },
@@ -80,7 +105,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_stairs' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_stairs`
         },
@@ -91,7 +121,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_stairs' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_stairs`
         },
@@ -102,7 +137,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_slab' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_slab`
         },
@@ -113,7 +153,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_wall' },
                 { type: 'damage_item', damage: 50 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.stone.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_wall`
         },
@@ -124,7 +169,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:damaged_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.large_amethyst_bud.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/damaged_budding_quartz`
         },
@@ -135,7 +185,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:chipped_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.large_amethyst_bud.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/chipped_budding_quartz`
         },
@@ -146,7 +201,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawed_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.large_amethyst_bud.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawed_budding_quartz`
         },
@@ -157,7 +217,12 @@ ServerEvents.recipes((event) => {
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawless_budding_quartz' },
                 { type: 'damage_item', damage: 200 },
-                { type: 'add_item_cooldown', s: 2 }
+                { type: 'add_item_cooldown', s: 2 },
+                {
+                    type: 'execute',
+                    command: 'playsound minecraft:block.large_amethyst_bud.place block @p ~ ~ ~',
+                    hide: true
+                }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawless_budding_quartz`
         }

--- a/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
+++ b/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
@@ -2,6 +2,10 @@ ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/lychee/block_interacting/';
 
     // Todo: Add sound effects to these with https://lycheetweaker.readthedocs.io/en/latest/post-action/#execute-command-execute
+    // https://www.digminecraft.com/game_commands/playsound_command.php
+
+    // Stone sound: block.stone.place
+    // certus sound:
     const recipes = [
         {
             item_in: { item: 'naturesaura:infused_iron_pickaxe' },
@@ -9,7 +13,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone`
         },
@@ -19,7 +24,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'farmersdelight:rich_soil_farmland' },
-                { type: 'damage_item', damage: 25 }
+                { type: 'damage_item', damage: 25 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/rich_soil_farmland`
         },
@@ -29,7 +35,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:moss_block' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/moss_block`
         },
@@ -39,7 +46,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'twilightforest:liveroot_block' },
-                { type: 'damage_item', damage: 125 }
+                { type: 'damage_item', damage: 125 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/liveroot_block`
         },
@@ -49,7 +57,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_bricks' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_bricks`
         },
@@ -59,7 +68,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_wall' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_wall`
         },
@@ -69,7 +79,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_stone_brick_stairs' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_stairs`
         },
@@ -79,7 +90,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_stairs' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_stairs`
         },
@@ -89,7 +101,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_slab' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_slab`
         },
@@ -99,7 +112,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'minecraft:mossy_cobblestone_wall' },
-                { type: 'damage_item', damage: 50 }
+                { type: 'damage_item', damage: 50 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_wall`
         },
@@ -109,7 +123,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:damaged_budding_quartz' },
-                { type: 'damage_item', damage: 200 }
+                { type: 'damage_item', damage: 200 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/damaged_budding_quartz`
         },
@@ -119,7 +134,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:chipped_budding_quartz' },
-                { type: 'damage_item', damage: 200 }
+                { type: 'damage_item', damage: 200 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/chipped_budding_quartz`
         },
@@ -129,7 +145,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawed_budding_quartz' },
-                { type: 'damage_item', damage: 200 }
+                { type: 'damage_item', damage: 200 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawed_budding_quartz`
         },
@@ -139,7 +156,8 @@ ServerEvents.recipes((event) => {
             post: [
                 { type: 'prevent_default' },
                 { type: 'place', block: 'ae2:flawless_budding_quartz' },
-                { type: 'damage_item', damage: 200 }
+                { type: 'damage_item', damage: 200 },
+                { type: 'add_item_cooldown', s: 5 }
             ],
             id: `${id_prefix}infused_iron_pickaxe_conversions/flawless_budding_quartz`
         }

--- a/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
+++ b/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
@@ -1,0 +1,150 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/lychee/block_interacting/';
+    const recipes = [
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:cobblestone',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_cobblestone' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:farmland',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'farmersdelight:rich_soil_farmland' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/rich_soil_farmland`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:stone',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:moss_block' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/moss_block`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'twilightforest:root',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'twilightforest:liveroot_block' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/liveroot_block`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:stone_bricks',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_stone_bricks' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_bricks`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:stone_brick_wall',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_stone_brick_wall' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_wall`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:stone_brick_stairs',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_stone_brick_stairs' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_stone_brick_stairs`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:cobblestone_stairs',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_cobblestone_stairs' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_stairs`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:cobblestone_slab',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_cobblestone_slab' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_slab`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'minecraft:cobblestone_wall',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'minecraft:mossy_cobblestone_wall' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/mossy_cobblestone_wall`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'ae2:quartz_block',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'ae2:damaged_budding_quartz' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/damaged_budding_quartz`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'ae2:damaged_budding_quartz',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'ae2:chipped_budding_quartz' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/chipped_budding_quartz`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'ae2:chipped_budding_quartz',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'ae2:flawed_budding_quartz' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/flawed_budding_quartz`
+        },
+        {
+            item_in: { item: 'naturesaura:infused_iron_pickaxe' },
+            block_in: 'ae2:flawed_budding_quartz',
+            post: [
+                { type: 'prevent_default' },
+                { type: 'place', block: 'ae2:flawless_budding_quartz' },
+                { type: 'damage_item', damage: 100 }
+            ],
+            id: `${id_prefix}infused_iron_pickaxe_conversions/flawless_budding_quartz`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'lychee:block_interacting';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
+++ b/kubejs/server_scripts/base/recipes/lychee/block_interacting.js
@@ -1,5 +1,7 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/lychee/block_interacting/';
+
+    // Todo: Add sound effects to these with https://lycheetweaker.readthedocs.io/en/latest/post-action/#execute-command-execute
     const recipes = [
         {
             item_in: { item: 'naturesaura:infused_iron_pickaxe' },

--- a/kubejs/server_scripts/base/tags/blocks/ars_nouveau/golem.js
+++ b/kubejs/server_scripts/base/tags/blocks/ars_nouveau/golem.js
@@ -1,0 +1,6 @@
+ServerEvents.tags('block', (event) => {
+    // Blocks to be accelerated by golems
+    event.add('ars_nouveau:golem/budding', ['minecraft:budding_amethyst']);
+    // Blocks to be broken by golems
+    event.add('ars_nouveau:golem/cluster', ['minecraft:amethyst_cluster']);
+});

--- a/kubejs/server_scripts/base/tags/blocks/ars_nouveau/golem.js
+++ b/kubejs/server_scripts/base/tags/blocks/ars_nouveau/golem.js
@@ -1,6 +1,12 @@
 ServerEvents.tags('block', (event) => {
     // Blocks to be accelerated by golems
-    event.add('ars_nouveau:golem/budding', ['minecraft:budding_amethyst']);
+    event.add('ars_nouveau:golem/budding', [
+        'minecraft:budding_amethyst',
+        'ae2:damaged_budding_quartz',
+        'ae2:chipped_budding_quartz',
+        'ae2:flawed_budding_quartz',
+        'ae2:flawless_budding_quartz'
+    ]);
     // Blocks to be broken by golems
-    event.add('ars_nouveau:golem/cluster', ['minecraft:amethyst_cluster']);
+    event.add('ars_nouveau:golem/cluster', ['minecraft:amethyst_cluster', 'ae2:quartz_cluster']);
 });

--- a/kubejs/server_scripts/base/tags/items/ars_nouveau/golem.js
+++ b/kubejs/server_scripts/base/tags/items/ars_nouveau/golem.js
@@ -1,0 +1,4 @@
+ServerEvents.tags('item', (event) => {
+    // Items golems can pick up
+    event.add('ars_nouveau:golem/shard', ['minecraft:amethyst_shard']);
+});

--- a/kubejs/server_scripts/base/tags/items/ars_nouveau/golem.js
+++ b/kubejs/server_scripts/base/tags/items/ars_nouveau/golem.js
@@ -1,4 +1,4 @@
 ServerEvents.tags('item', (event) => {
     // Items golems can pick up
-    event.add('ars_nouveau:golem/shard', ['minecraft:amethyst_shard']);
+    event.add('ars_nouveau:golem/shard', ['minecraft:amethyst_shard', 'ae2:certus_quartz_crystal']);
 });


### PR DESCRIPTION
Allows Certus Quartz to be boosted and harvested by AN's Amethyst Golem
Converts all Nature's Aura Right Click interactions for the Infused Iron Pick to be Lychee recipes instead. This way they show in JEI and are more easily discoverable. This also allows more granular control of the durability cost of certain conversions.
Create high durability cost recipe for AE2 budding certus, allowing one to upgrade from a basic block of certus quartz up to a flawless budding block.
