### PR TITLE
Convert PNC spawned mobs to Spirit Corrupted mobs

### DIFF
--- a/kubejs/server_scripts/base/entity_events/spawned/equipment.js
+++ b/kubejs/server_scripts/base/entity_events/spawned/equipment.js
@@ -11,6 +11,13 @@ EntityEvents.spawned((event) => {
         event.entity.fullNBT = entity_data;
     }
 
+    // Make PNC spawners create Corrupted mobs (from Spirit)
+    if (event.entity.fullNBT.ForgeData.hasOwnProperty('pneumaticcraft:pressurized_spawner')) {
+        entity_data = event.entity.fullNBT;
+        entity_data.Corrupted = true;
+        event.entity.fullNBT = entity_data;
+    }
+
     // Don't apply buffs to Spirit spawner mobs
     // Don't apply buffs to Apotheosis bosses
     // Don't re-apply buffs to already checked mobs


### PR DESCRIPTION
Just makes a nice thematic compat since both come from vanilla spawners. Adds a pretty overlay to the mobs and prevents all the extra stuff added to world-gen mobs from appearing on them as well.

Not quite functional yet as there's a small bug in PNC that's leading to a timing issue (they don't spawn with the PNC tags, they get it a moment later instead). Desht is looking into that, however, and this won't break anything in the meantime. 