### PR TITLE
Disable wearable shulker shells

### DIFF
--- a/config/supplementaries-common.toml
+++ b/config/supplementaries-common.toml
@@ -313,7 +313,7 @@
 
 	[tweaks.shulker_helmet]
 		#Allows wearing shulker shells
-		enabled = true
+		enabled = false
 
 	[tweaks.traders_open_doors]
 		#Allows traders to open doors (because they couldnt aparently)


### PR DESCRIPTION
It's causing apotheosis to lootify them and that makes them a mess to farm.