### PR TITLE
Fix missing loot in Industrial Foregoing quest chapter

### DIFF
--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -1061,6 +1061,14 @@
 				type: "item"
 				item: "industrialforegoing:machine_frame_pity"
 			}]
+			rewards: [{
+				id: "35A7641EB7485F84"
+				type: "command"
+				title: "Farmer's Delight"
+				icon: "kubejs:farmers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
+				player_command: false
+			}]
 		}
 		{
 			title: "Getting Started: Farm Management"
@@ -1188,6 +1196,14 @@
 				type: "item"
 				item: "industrialforegoing:sewer"
 			}]
+			rewards: [{
+				id: "0A5DDA176392D6E1"
+				type: "command"
+				title: "Scavenger's Delight"
+				icon: "kubejs:scavengers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				player_command: false
+			}]
 		}
 		{
 			x: 2.5d
@@ -1200,6 +1216,14 @@
 				id: "401D06401D348995"
 				type: "item"
 				item: "industrialforegoing:sewage_composter"
+			}]
+			rewards: [{
+				id: "759901F1E0E1D611"
+				type: "command"
+				title: "Scavenger's Delight"
+				icon: "kubejs:scavengers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				player_command: false
 			}]
 		}
 		{
@@ -1220,6 +1244,14 @@
 				type: "item"
 				item: "industrialforegoing:plant_gatherer"
 			}]
+			rewards: [{
+				id: "75698CB62EFD1F72"
+				type: "command"
+				title: "Farmer's Delight"
+				icon: "kubejs:farmers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
+				player_command: false
+			}]
 		}
 		{
 			x: 0.5d
@@ -1236,6 +1268,14 @@
 				id: "509B5025C6D86A2A"
 				type: "item"
 				item: "industrialforegoing:plant_sower"
+			}]
+			rewards: [{
+				id: "7F04572BDD87A1BF"
+				type: "command"
+				title: "Farmer's Delight"
+				icon: "kubejs:farmers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
+				player_command: false
 			}]
 		}
 		{
@@ -1280,6 +1320,14 @@
 				type: "item"
 				item: "industrialforegoing:spores_recreator"
 			}]
+			rewards: [{
+				id: "34E4B9B36B6E6628"
+				type: "command"
+				title: "Scavenger's Delight"
+				icon: "kubejs:scavengers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				player_command: false
+			}]
 		}
 		{
 			x: 0.5d
@@ -1292,6 +1340,14 @@
 				id: "10D08B53CA796681"
 				type: "item"
 				item: "industrialforegoing:sludge_refiner"
+			}]
+			rewards: [{
+				id: "52072317D15EFCBE"
+				type: "command"
+				title: "Farmer's Delight"
+				icon: "kubejs:farmers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
+				player_command: false
 			}]
 		}
 		{

--- a/kubejs/server_scripts/base/loot_tables/chests/enigmatica/industrial_foregoing_loot_boxes.js
+++ b/kubejs/server_scripts/base/loot_tables/chests/enigmatica/industrial_foregoing_loot_boxes.js
@@ -1,0 +1,86 @@
+ServerEvents.genericLootTables((event) => {
+    event.addGeneric('enigmatica:loot_boxes/industrial_foregoing/rare', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 2.0;
+            pool.addItem('industrialforegoing:machine_frame_simple', 10, 1);
+            pool.addItem('industrialforegoing:item_transporter_type', 10, 2);
+            pool.addItem('industrialforegoing:fluid_transporter_type', 10, 2);
+            pool.addItem('thermal:rubber', 10, [8, 16]);
+            pool.addItem('industrialforegoing:plastic', 10, [8, 16]);
+            pool.addItem('industrialforegoing:laser_drill', 1, 1);
+            pool.addItem('industrialforegoing:mechanical_dirt', 1, [1, 3]);
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = [1, 3];
+            pool.addItem(Item.of('industrialforegoing:speed_addon_1', '{TitaniumAugment:{Speed:2.0f}}'), 1, 1);
+            pool.addItem(
+                Item.of('industrialforegoing:efficiency_addon_1', '{TitaniumAugment:{Efficiency:0.9f}}'),
+                1,
+                1
+            );
+            pool.addItem(
+                Item.of('industrialforegoing:processing_addon_1', '{TitaniumAugment:{Processing:2.0f}}'),
+                1,
+                1
+            );
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addEntry({ type: 'loot_table', weight: 1, name: 'enigmatica:loot_boxes/special' });
+        });
+    });
+
+    event.addGeneric('enigmatica:loot_boxes/industrial_foregoing/epic', (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 2.0;
+            pool.addItem('industrialforegoing:mob_imprisonment_tool', 5, 1);
+            pool.addItem('industrialforegoing:machine_frame_advanced', 30, 1);
+            pool.addItem(
+                Item.of(
+                    'pneumaticcraft:huge_tank',
+                    '{BlockEntityTag:{SavedTanks:{Tank:{Amount:512000,FluidName:"industrialforegoing:sludge"}}}}'
+                ),
+                1,
+                1
+            );
+            pool.addItem(
+                Item.of(
+                    'pneumaticcraft:huge_tank',
+                    '{BlockEntityTag:{SavedTanks:{Tank:{Amount:512000,FluidName:"industrialforegoing:biofuel"}}}}'
+                ),
+                1,
+                1
+            );
+            pool.addItem(
+                Item.of(
+                    'pneumaticcraft:huge_tank',
+                    '{BlockEntityTag:{SavedTanks:{Tank:{Amount:512000,FluidName:"industrialforegoing:essence"}}}}'
+                ),
+                1,
+                1
+            );
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = [1, 3];
+            pool.addItem(Item.of('industrialforegoing:speed_addon_2', '{TitaniumAugment:{Speed:3.0f}}'), 1, 1);
+            pool.addItem(
+                Item.of('industrialforegoing:efficiency_addon_2', '{TitaniumAugment:{Efficiency:0.8f}}'),
+                1,
+                1
+            );
+            pool.addItem(
+                Item.of('industrialforegoing:processing_addon_2', '{TitaniumAugment:{Processing:3.0f}}'),
+                1,
+                1
+            );
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.addEntry({ type: 'loot_table', weight: 1, name: 'enigmatica:loot_boxes/industrial_foregoing/rare' });
+        });
+    });
+});


### PR DESCRIPTION
Loot tables were missing entirely, oops! Also adds loot to some quests that had none previously.