### PR TITLE
Rebalance Enigmatic Unity power conversion

### DIFF
--- a/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
@@ -3,7 +3,7 @@
 auraConversion = 40.0
 #Conversion multiplier from Source to Power
 #Range: 4.9E-324 ~ 1.7976931348623157E308
-sourceConversion = 400.0
+sourceConversion = 200.0
 
 ["Dim type"]
 	#Power Buffer size  of the Dim type
@@ -23,7 +23,7 @@ sourceConversion = 400.0
 	amountperoperation = 50
 	#Amount of Aura to drain/provide when theDim type operates
 	#Range: > 0
-	change = 500
+	change = 750
 
 ["Bright type"]
 	#Power Buffer size  of the Bright type
@@ -43,7 +43,7 @@ sourceConversion = 400.0
 	amountperoperation = 50
 	#Amount of Aura to drain/provide when theBright type operates
 	#Range: > 0
-	change = 3500
+	change = 3750
 
 ["Iridescent type"]
 	#Power Buffer size  of the Iridescent type
@@ -63,5 +63,5 @@ sourceConversion = 400.0
 	amountperoperation = 50
 	#Amount of Aura to drain/provide when theIridescent type operates
 	#Range: > 0
-	change = 7500
+	change = 7750
 

--- a/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
@@ -1,9 +1,9 @@
 #Conversion multiplier from Aura to Power
 #Range: 4.9E-324 ~ 1.7976931348623157E308
-auraConversion = 20.0
+auraConversion = 40.0
 #Conversion multiplier from Source to Power
 #Range: 4.9E-324 ~ 1.7976931348623157E308
-sourceConversion = 10.0
+sourceConversion = 400.0
 
 ["Dim type"]
 	#Power Buffer size  of the Dim type
@@ -20,10 +20,10 @@ sourceConversion = 10.0
 	tickinterval = 80
 	#Amount of Source to convert per Operation with the Dim type
 	#Range: > 0
-	amountperoperation = 1000
+	amountperoperation = 50
 	#Amount of Aura to drain/provide when theDim type operates
 	#Range: > 0
-	change = 1500
+	change = 500
 
 ["Bright type"]
 	#Power Buffer size  of the Bright type
@@ -40,10 +40,10 @@ sourceConversion = 10.0
 	tickinterval = 40
 	#Amount of Source to convert per Operation with the Bright type
 	#Range: > 0
-	amountperoperation = 1000
+	amountperoperation = 50
 	#Amount of Aura to drain/provide when theBright type operates
 	#Range: > 0
-	change = 7500
+	change = 3500
 
 ["Iridescent type"]
 	#Power Buffer size  of the Iridescent type
@@ -60,8 +60,8 @@ sourceConversion = 10.0
 	tickinterval = 20
 	#Amount of Source to convert per Operation with the Iridescent type
 	#Range: > 0
-	amountperoperation = 1000
+	amountperoperation = 50
 	#Amount of Aura to drain/provide when theIridescent type operates
 	#Range: > 0
-	change = 15500
+	change = 7500
 

--- a/config/configswapper/normal/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/normal/serverconfig/enigmaticunity-server.toml
@@ -3,7 +3,7 @@
 auraConversion = 40.0
 #Conversion multiplier from Source to Power
 #Range: 4.9E-324 ~ 1.7976931348623157E308
-sourceConversion = 400.0
+sourceConversion = 200.0
 
 ["Dim type"]
 	#Power Buffer size  of the Dim type
@@ -23,7 +23,7 @@ sourceConversion = 400.0
 	amountperoperation = 50
 	#Amount of Aura to drain/provide when theDim type operates
 	#Range: > 0
-	change = 500
+	change = 750
 
 ["Bright type"]
 	#Power Buffer size  of the Bright type
@@ -43,7 +43,7 @@ sourceConversion = 400.0
 	amountperoperation = 50
 	#Amount of Aura to drain/provide when theBright type operates
 	#Range: > 0
-	change = 3500
+	change = 3750
 
 ["Iridescent type"]
 	#Power Buffer size  of the Iridescent type
@@ -63,5 +63,5 @@ sourceConversion = 400.0
 	amountperoperation = 50
 	#Amount of Aura to drain/provide when theIridescent type operates
 	#Range: > 0
-	change = 7500
+	change = 7750
 

--- a/config/configswapper/normal/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/normal/serverconfig/enigmaticunity-server.toml
@@ -1,9 +1,9 @@
 #Conversion multiplier from Aura to Power
 #Range: 4.9E-324 ~ 1.7976931348623157E308
-auraConversion = 20.0
+auraConversion = 40.0
 #Conversion multiplier from Source to Power
 #Range: 4.9E-324 ~ 1.7976931348623157E308
-sourceConversion = 10.0
+sourceConversion = 400.0
 
 ["Dim type"]
 	#Power Buffer size  of the Dim type
@@ -20,10 +20,10 @@ sourceConversion = 10.0
 	tickinterval = 80
 	#Amount of Source to convert per Operation with the Dim type
 	#Range: > 0
-	amountperoperation = 1000
+	amountperoperation = 50
 	#Amount of Aura to drain/provide when theDim type operates
 	#Range: > 0
-	change = 1500
+	change = 500
 
 ["Bright type"]
 	#Power Buffer size  of the Bright type
@@ -40,10 +40,10 @@ sourceConversion = 10.0
 	tickinterval = 40
 	#Amount of Source to convert per Operation with the Bright type
 	#Range: > 0
-	amountperoperation = 1000
+	amountperoperation = 50
 	#Amount of Aura to drain/provide when theBright type operates
 	#Range: > 0
-	change = 7500
+	change = 3500
 
 ["Iridescent type"]
 	#Power Buffer size  of the Iridescent type
@@ -60,8 +60,8 @@ sourceConversion = 10.0
 	tickinterval = 20
 	#Amount of Source to convert per Operation with the Iridescent type
 	#Range: > 0
-	amountperoperation = 1000
+	amountperoperation = 50
 	#Amount of Aura to drain/provide when theIridescent type operates
 	#Range: > 0
-	change = 15500
+	change = 7500
 


### PR DESCRIPTION
During testing, I started to notice that one of the big bottlenecks to the system was that Source relays couldn't transfer fast enough to keep up with the 1000 source per second usage of the previous configs. 

Since Source is primarily meant to be the activator here, or carrier, I'm dramatically reducing the amount pulled per operation from 1000 source to 50. 

This makes it easier for a network of relays to keep up with the Source draw, meaning more crystals can be run off of a single network.

This also pretty heavily boosts the 'worth' of Source in terms of FE, but still keeps Aura as the dominant FE producer per tick. Aura also received a buff to slightly slow down the rate at which it is drained. 

Overall the total FE/t for each tier remains the same. They're just more efficient and take in smaller quantities at a time. 


| Tier       | FE/t from Source | FE/t from Aura |   Total   |
|------------|:----------------:|:--------------:|:---------:|
| Dim        |      125.00      |     375.00     |   500.00  |
| Bright     |      250.00      |    3,750.00    |  4,000.00 |
| Iridescent |      500.00      |    15,500.00   | 16,000.00 |