### PR TITLE
Expert Playtest feedback fixes

### DIFF
--- a/config/configswapper/expert/config/emendatusenigmatica/material/gold.json
+++ b/config/configswapper/expert/config/emendatusenigmatica/material/gold.json
@@ -1,0 +1,36 @@
+{
+    "id": "gold",
+    "source": "vanilla",
+    "localizedName": "Gold",
+    "disableDefaultOre": true,
+    "processedTypes": [
+        "storage_block",
+        "ore",
+        "raw",
+        "crushed_ore",
+        "ingot",
+        "nugget",
+        "dust",
+        "plate",
+        "rod",
+        "gear",
+        "slurry",
+        "crystal",
+        "shard",
+        "clump",
+        "dirty_dust"
+    ],
+    "properties": {
+        "materialType": "metal",
+        "harvestLevel": 1,
+        "isEmissive": true
+    },
+    "oreDrop": {
+        "drop": "minecraft:raw_gold",
+        "min": 1,
+        "max": 1
+    },
+    "colors": {
+        "gasColor": "f5c938"
+    }
+}

--- a/config/configswapper/normal/config/emendatusenigmatica/material/gold.json
+++ b/config/configswapper/normal/config/emendatusenigmatica/material/gold.json
@@ -1,0 +1,36 @@
+{
+    "id": "gold",
+    "source": "vanilla",
+    "localizedName": "Gold",
+    "disableDefaultOre": true,
+    "processedTypes": [
+        "storage_block",
+        "ore",
+        "raw",
+        "crushed_ore",
+        "ingot",
+        "nugget",
+        "dust",
+        "plate",
+        "rod",
+        "gear",
+        "slurry",
+        "crystal",
+        "shard",
+        "clump",
+        "dirty_dust"
+    ],
+    "properties": {
+        "materialType": "metal",
+        "harvestLevel": 2,
+        "isEmissive": true
+    },
+    "oreDrop": {
+        "drop": "minecraft:raw_gold",
+        "min": 1,
+        "max": 1
+    },
+    "colors": {
+        "gasColor": "f5c938"
+    }
+}

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -387,7 +387,7 @@
 		}
 		{
 			dependencies: ["6DBB9A9F698FA7B9"]
-			description: ["Obtain a bottle of Sunlight and Right-Click a block of Ironwood to convert it to a Natural Altar. Be sure to build the rest of the required structure as well."]
+			description: ["Obtain a Gold Leaf and Right-Click a block of Ironwood to convert it to a Natural Altar. Be sure to build the rest of the required structure as well."]
 			id: "4B874AA448FF4C7A"
 			rewards: [{
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
@@ -397,11 +397,18 @@
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
-			tasks: [{
-				id: "210D29FCB8E3D805"
-				item: "naturesaura:nature_altar"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "210D29FCB8E3D805"
+					item: "naturesaura:nature_altar"
+					type: "item"
+				}
+				{
+					id: "10897A1810BFBEAD"
+					item: "naturesaura:gold_leaf"
+					type: "item"
+				}
+			]
 			x: -3.5d
 			y: -1.5d
 		}
@@ -1248,6 +1255,7 @@
 			]
 			id: "438EA01F776992AD"
 			rewards: [{
+				count: 4
 				id: "374D86C82113C057"
 				item: "minecraft:hopper"
 				type: "item"

--- a/kubejs/client_scripts/base/jei_descriptions.js
+++ b/kubejs/client_scripts/base/jei_descriptions.js
@@ -365,6 +365,10 @@ JEIEvents.information((event) => {
         {
             items: ['twilightforest:borer_essence'],
             text: [`Drops from Towerwood Borers.`]
+        },
+        {
+            items: ['twilightforest:liveroot'],
+            text: [`Drops from Liveroots found under trees in the Twilight Forest.`]
         }
     ];
 

--- a/kubejs/server_scripts/base/tags/blocks/ars_nouveau/gravity_blacklist.js
+++ b/kubejs/server_scripts/base/tags/blocks/ars_nouveau/gravity_blacklist.js
@@ -1,0 +1,3 @@
+ServerEvents.tags('block', (event) => {
+    event.add('ars_nouveau:gravity_blacklist', ['ae2:flawless_budding_quartz']);
+});

--- a/kubejs/server_scripts/base/tags/blocks/ars_nouveau/whirlisprig.js
+++ b/kubejs/server_scripts/base/tags/blocks/ars_nouveau/whirlisprig.js
@@ -1,0 +1,5 @@
+ServerEvents.tags('block', (event) => {
+    event.add('ars_nouveau:whirlisprig/greatly_likes', ['twilightforest:liveroot_block']);
+
+    // event.add('ars_nouveau:whirlisprig/kinda_likes', []);
+});

--- a/kubejs/server_scripts/expert/recipes/enigmatica/crushing_tiers.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/crushing_tiers.js
@@ -81,7 +81,7 @@ ServerEvents.recipes((event) => {
                     ],
                     output: {
                         item: recipe.outputs.primary,
-                        count: 5
+                        count: 12
                     },
                     grindingTime: duration * 5
                 })

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -326,6 +326,7 @@ ServerEvents.recipes((event) => {
         { id: 'minecraft:netherite_ingot' },
         { id: 'minecraft:lodestone' },
         { id: 'minecraft:golden_apple' },
+        { id: 'minecraft:string' },
 
         { id: 'modularrouters:sender_module_1_alt' },
         { id: 'modularrouters:sender_module_2_x4' },
@@ -536,6 +537,7 @@ ServerEvents.recipes((event) => {
         { id: /emendatusenigmatica:.*from_ingot/ },
         { id: /emendatusenigmatica:.*from_gem/ },
         { id: /emendatusenigmatica:slurry\/clean/ },
+        { id: /quark:tweaks\/smelting\/raw/ },
 
         { type: 'minecraft:smelting', output: '#forge:nuggets' },
         { type: 'minecraft:smelting', output: '#forge:ingots' },

--- a/kubejs/server_scripts/expert/recipes/enigmatica/replace_input.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/replace_input.js
@@ -15,12 +15,12 @@ ServerEvents.recipes((event) => {
         {
             filter: { output: 'minecraft:hopper' },
             to_replace: '#forge:ingots/iron',
-            replace_with: '#forge:plates/tin'
+            replace_with: '#forge:ingots/tin'
         },
         {
             filter: { output: 'minecraft:bucket' },
             to_replace: '#forge:ingots/iron',
-            replace_with: '#forge:plates/tin'
+            replace_with: '#forge:ingots/tin'
         },
         {
             filter: { mod: 'create' },

--- a/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
+++ b/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
@@ -137,6 +137,24 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}magebloom_crop`
         },
         {
+            output: 'ars_nouveau:magebloom_crop',
+            inputs: [
+                'immersiveengineering:seed',
+                'ars_nouveau:magebloom',
+                'hexerei:belladonna_berries',
+                'ars_nouveau:magebloom',
+                'hexerei:mandrake_root',
+                'ars_nouveau:magebloom',
+                'hexerei:belladonna_berries',
+                'ars_nouveau:magebloom'
+            ],
+            liquid: { fluid: 'minecraft:water' },
+            liquidOutput: { fluid: 'minecraft:water' },
+            fluidLevelsConsumed: 250,
+            heatRequirement: 'heated',
+            id: `${id_prefix}magebloom_crop_from_magebloom`
+        },
+        {
             output: 'superiorshields:ironwood_shield',
             inputs: [
                 '#forge:storage_blocks/source',

--- a/kubejs/server_scripts/expert/recipes/twilightforest/hollow_hills.js
+++ b/kubejs/server_scripts/expert/recipes/twilightforest/hollow_hills.js
@@ -15,8 +15,10 @@ ServerEvents.highPriorityData((event) => {
                 'twilightforest:calcite_stalactite',
 
                 'twilightforest:gold_ore_stalactite',
+                'twilightforest:iron_ore_stalactite',
                 'twilightforest:silver_ore_stalactite',
-                'twilightforest:copper_ore_stalactite'
+                'twilightforest:copper_ore_stalactite',
+                'twilightforest:tin_ore_stalactite'
             ]
         },
         {


### PR DESCRIPTION
- Fix rates from crushing ore in mortar and pestle. Was unintentionally low due to other changes.
- Remove Raw Block > metal block processing which allowed early access to iron
- Add note to Liveroot on where to find it
- Allow liveroot to be harvested by whirlisprigs
- Magebloom Seeds have a cheaper secondary recipe once the first has been made
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/1e2cfb54-1a4e-48a2-be33-e164f18b1db9)
- Hoppers and Buckets now use Tin Ingots instead of Plates. You also get 4 free hoppers from early ore processing quests. Yay!
- Gold Ore harvest level reduced to simplify tool progression. 

