### PR TITLE
Expert: QoL

### DIFF
--- a/kubejs/server_scripts/expert/recipes/enigmatica/replace_input.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/replace_input.js
@@ -190,6 +190,41 @@ ServerEvents.recipes((event) => {
             filter: { output: /minecart/ },
             to_replace: '#forge:ingots/iron',
             replace_with: '#forge:ingots/tin'
+        },
+        {
+            filter: { output: /thermal:.*_grenade/ },
+            to_replace: '#forge:ingots/iron',
+            replace_with: '#forge:nuggets/lead'
+        },
+        {
+            filter: { mod: 'toolbelt' },
+            to_replace: 'minecraft:leather',
+            replace_with: '#forge:leather'
+        },
+        {
+            filter: { mod: 'supplementaries' },
+            to_replace: 'minecraft:leather',
+            replace_with: '#forge:leather'
+        },
+        {
+            filter: { mod: 'cnb' },
+            to_replace: 'minecraft:leather',
+            replace_with: '#forge:leather'
+        },
+        {
+            filter: { mod: 'ars_nouveau' },
+            to_replace: 'minecraft:leather',
+            replace_with: '#forge:leather'
+        },
+        {
+            filter: { output: /item_frame/ },
+            to_replace: 'minecraft:leather',
+            replace_with: '#forge:leather'
+        },
+        {
+            filter: { output: 'minecraft:book' },
+            to_replace: 'minecraft:leather',
+            replace_with: '#forge:leather'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
+++ b/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
@@ -882,6 +882,60 @@ ServerEvents.recipes((event) => {
             fluidLevelsConsumed: 1000,
             heatRequirement: 'heated',
             id: 'hexerei:candle_dipper_from_mixing_cauldron'
+        },
+        {
+            output: 'hexerei:small_satchel',
+            inputs: [
+                '#forge:string',
+                '#forge:leather',
+                '#forge:leather',
+                '#forge:leather',
+                '#forge:nuggets/silver',
+                '#forge:leather',
+                '#forge:leather',
+                '#forge:leather'
+            ],
+            liquid: { fluid: 'minecraft:water' },
+            liquidOutput: { fluid: 'minecraft:water' },
+            fluidLevelsConsumed: 500,
+            heatRequirement: 'heated',
+            id: 'hexerei:small_satchel_from_mixing_cauldron'
+        },
+        {
+            output: 'hexerei:medium_satchel',
+            inputs: [
+                'hexerei:small_satchel',
+                '#forge:leather',
+                '#forge:leather',
+                '#forge:leather',
+                '#forge:string',
+                '#forge:leather',
+                '#forge:leather',
+                '#forge:leather'
+            ],
+            liquid: { fluid: 'minecraft:water' },
+            liquidOutput: { fluid: 'minecraft:water' },
+            fluidLevelsConsumed: 500,
+            heatRequirement: 'heated',
+            id: 'hexerei:medium_satchel_from_mixing_cauldron'
+        },
+        {
+            output: 'hexerei:large_satchel',
+            inputs: [
+                'hexerei:small_satchel',
+                '#forge:string',
+                '#forge:leather',
+                '#forge:string',
+                'hexerei:medium_satchel',
+                '#forge:string',
+                '#forge:leather',
+                '#forge:string'
+            ],
+            liquid: { fluid: 'minecraft:water' },
+            liquidOutput: { fluid: 'minecraft:water' },
+            fluidLevelsConsumed: 500,
+            heatRequirement: 'heated',
+            id: 'hexerei:large_satchel_from_mixing_cauldron'
         }
     ];
 

--- a/kubejs/startup_scripts/better_stacks.js
+++ b/kubejs/startup_scripts/better_stacks.js
@@ -18,6 +18,8 @@ ItemEvents.modification((event) => {
 
         'the_bumblezone:pollen_puff',
 
+        /thermal:.*_grenade/,
+
         //signs
         /(minecraft|supplementaries|twilightforest):\w+_sign/
     ];


### PR DESCRIPTION
Ersatz Leather can be used in more leather recipes. 
Grenades use lead nuggets instead of iron ingots. Now stack to 64