### PR TITLE
Fix Powah Reactor recipe

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Fixed Bugs
 
+-   Fix Powah Reactor recipe [\#409](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/409) ([MuteTiefling](https://github.com/MuteTiefling))
+
 ---
 
 ### Enigmatica 9 v1.7.2

--- a/kubejs/server_scripts/normal/recipes/powah/shaped.js
+++ b/kubejs/server_scripts/normal/recipes/powah/shaped.js
@@ -147,7 +147,7 @@ ServerEvents.recipes((event) => {
             output: 'powah:reactor_basic',
             pattern: ['ABA', 'BCB', 'ABA'],
             key: {
-                A: 'twilightforest:carminite',
+                A: '#forge:gems/carminite',
                 B: 'powah:capacitor_basic_large',
                 C: 'powah:dielectric_casing'
             },


### PR DESCRIPTION
Wrong type of carminite was used.