### PR TITLE
Fix for unobtainable nickel

### DIFF
--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -38,6 +38,7 @@ ServerEvents.recipes((event) => {
         { id: 'create:compat/ae2/mixing/fluix_crystal' },
         { id: 'create:compat/byg/crushing/lignite_ore' },
         { id: 'create:crushing/blaze_rod' },
+        { id: 'create:milling/sandstone' },
 
         { id: /createaddition:mixing\/biomass/ },
         { id: /createaddition:crafting\/.*spool/ },

--- a/kubejs/server_scripts/expert/recipes/create/filling.js
+++ b/kubejs/server_scripts/expert/recipes/create/filling.js
@@ -28,17 +28,6 @@ ServerEvents.recipes((event) => {
         }
     ];
 
-    simple_metals.forEach((metal) => {
-        recipes.push({
-            results: [{ item: `emendatusenigmatica:${metal}_dirty_dust`, count: 2 }],
-            ingredients: [
-                { item: `emendatusenigmatica:crushed_${metal}_ore` },
-                { fluidTag: 'forge:sulfuric_acid', amount: 10 }
-            ],
-            id: `${id_prefix}${metal}_dirty_dust_from_acid`
-        });
-    });
-
     recipes.forEach((recipe) => {
         recipe.type = 'create:filling';
         event.custom(recipe).id(recipe.id);

--- a/kubejs/server_scripts/expert/recipes/create/mixing.js
+++ b/kubejs/server_scripts/expert/recipes/create/mixing.js
@@ -13,6 +13,21 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}iron_dust_from_redstone_acid`
         },
         {
+            results: [
+                { item: 'emendatusenigmatica:iron_dirty_dust', count: 6 },
+                {
+                    item: AlmostUnified.getPreferredItemForTag(
+                        `mekanism:dirty_dusts/${metal_properties.iron.oreProcessing.expert_output.secondary}`
+                    ).getId(),
+                    count: 1
+                }
+            ],
+            ingredients: [{ tag: 'create:crushed_ores/iron' }, { fluidTag: 'forge:sulfuric_acid', amount: 30 }],
+            heatRequirement: 'superheated',
+
+            id: `${id_prefix}iron_dust_from_sulfuric_acid`
+        },
+        {
             results: [{ amount: 100, fluid: 'minecraft:water' }, { item: 'thermal:rubber' }],
             ingredients: [{ amount: 900, fluidTag: 'forge:latex' }],
             heatRequirement: 'heated',

--- a/kubejs/server_scripts/expert/recipes/create/mixing.js
+++ b/kubejs/server_scripts/expert/recipes/create/mixing.js
@@ -7,30 +7,19 @@ ServerEvents.recipes((event) => {
 
     const recipes = [
         {
-            ingredients: [{ tag: 'create:crushed_ores/iron' }, { amount: 100, fluidTag: 'forge:redstone_acid' }],
-            results: [
-                { item: 'emendatusenigmatica:iron_dirty_dust', count: 2 },
-                {
-                    item: `emendatusenigmatica:${metal_properties['iron'].oreProcessing.expert_output.secondary}_dirty_dust`,
-                    count: 1,
-                    chance: 0.3
-                },
-                {
-                    item: `emendatusenigmatica:${metal_properties['iron'].oreProcessing.expert_output.secondary}_dirty_dust`,
-                    count: 1,
-                    chance: 0.1
-                }
-            ],
+            results: [{ item: 'emendatusenigmatica:iron_dirty_dust', count: 1 }],
+            ingredients: [{ tag: 'create:crushed_ores/iron' }, { fluidTag: 'forge:redstone_acid', amount: 50 }],
             heatRequirement: 'superheated',
             id: `${id_prefix}iron_dust_from_redstone_acid`
         },
         {
-            ingredients: [{ amount: 900, fluidTag: 'forge:latex' }],
             results: [{ amount: 100, fluid: 'minecraft:water' }, { item: 'thermal:rubber' }],
+            ingredients: [{ amount: 900, fluidTag: 'forge:latex' }],
             heatRequirement: 'heated',
             id: `${id_prefix}rubber`
         },
         {
+            results: [{ item: 'thermal:cured_rubber', count: 4 }],
             ingredients: [
                 { item: 'thermal:rubber' },
                 { item: 'thermal:rubber' },
@@ -39,11 +28,14 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:essences/fire' },
                 { amount: 1000, fluid: 'minecraft:water' }
             ],
-            results: [{ item: 'thermal:cured_rubber', count: 4 }],
             heatRequirement: 'heated',
             id: `${id_prefix}cured_rubber`
         },
         {
+            results: [
+                { item: 'powah:dielectric_paste', count: 32 },
+                { item: 'powah:dielectric_paste', count: 8, chance: 0.15 }
+            ],
             ingredients: [
                 { item: 'occultism:burnt_otherstone' },
                 { item: 'occultism:burnt_otherstone' },
@@ -52,14 +44,11 @@ ServerEvents.recipes((event) => {
                 { item: 'occultism:burnt_otherstone' },
                 { amount: 1000, fluidTag: 'forge:latex' }
             ],
-            results: [
-                { item: 'powah:dielectric_paste', count: 32 },
-                { item: 'powah:dielectric_paste', count: 8, chance: 0.15 }
-            ],
             heatRequirement: 'heated',
             id: `${id_prefix}dielectric_paste`
         },
         {
+            results: [{ item: 'supplementaries:soap', count: 6 }],
             ingredients: [
                 { tag: 'forge:dusts/ash' },
                 { tag: 'forge:dusts/ash' },
@@ -68,11 +57,11 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:tallow' },
                 { amount: 1000, fluidTag: 'forge:water' }
             ],
-            results: [{ item: 'supplementaries:soap', count: 6 }],
             heatRequirement: 'heated',
             id: `${id_prefix}soap`
         },
         {
+            results: [{ item: 'powah:crystal_blazing', count: 4 }],
             ingredients: [
                 { item: 'minecraft:blaze_powder' },
                 { item: 'minecraft:blaze_powder' },
@@ -81,11 +70,11 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:gems/prismarine' },
                 { amount: 1000, fluidTag: 'forge:blood' }
             ],
-            results: [{ item: 'powah:crystal_blazing', count: 4 }],
             heatRequirement: 'heated',
             id: `${id_prefix}crystal_blazing`
         },
         {
+            results: [{ item: 'emendatusenigmatica:bronze_dust', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/copper' },
                 { tag: 'forge:dusts/copper' },
@@ -93,10 +82,10 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:dusts/tin' },
                 { tag: 'forge:dusts/redstone' }
             ],
-            results: [{ item: 'emendatusenigmatica:bronze_dust', count: 4 }],
             id: `${id_prefix}bronze_dust`
         },
         {
+            results: [{ item: 'emendatusenigmatica:electrum_dust', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/silver' },
                 { tag: 'forge:dusts/silver' },
@@ -104,10 +93,10 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:dusts/gold' },
                 { tag: 'forge:dusts/redstone' }
             ],
-            results: [{ item: 'emendatusenigmatica:electrum_dust', count: 4 }],
             id: `${id_prefix}electrum_dust`
         },
         {
+            results: [{ item: 'emendatusenigmatica:invar_dust', count: 3 }],
             ingredients: [
                 { tag: 'forge:dusts/iron' },
                 { tag: 'forge:dusts/iron' },
@@ -115,10 +104,10 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:dusts/redstone' },
                 { tag: 'forge:dusts/redstone' }
             ],
-            results: [{ item: 'emendatusenigmatica:invar_dust', count: 3 }],
             id: `${id_prefix}invar_dust`
         },
         {
+            results: [{ item: 'emendatusenigmatica:constantan_dust', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/nickel' },
                 { tag: 'forge:dusts/nickel' },
@@ -126,10 +115,10 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:dusts/copper' },
                 { tag: 'forge:dusts/redstone' }
             ],
-            results: [{ item: 'emendatusenigmatica:constantan_dust', count: 4 }],
             id: `${id_prefix}constantan_dust`
         },
         {
+            results: [{ item: 'emendatusenigmatica:lumium_dust', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/constantan' },
                 { tag: 'forge:dusts/constantan' },
@@ -137,10 +126,10 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:dusts/constantan' },
                 [{ item: 'minecraft:glow_berries' }, { item: 'twilightforest:torchberries' }]
             ],
-            results: [{ item: 'emendatusenigmatica:lumium_dust', count: 4 }],
             id: `${id_prefix}lumium_dust`
         },
         {
+            results: [{ item: 'emendatusenigmatica:signalum_dust', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/aluminum' },
                 { tag: 'forge:dusts/aluminum' },
@@ -148,27 +137,56 @@ ServerEvents.recipes((event) => {
                 { tag: 'forge:dusts/aluminum' },
                 { tag: 'forge:esseneces/manipulation' }
             ],
-            results: [{ item: 'emendatusenigmatica:signalum_dust', count: 4 }],
             id: `${id_prefix}signalum_dust`
         },
         {
-            ingredients: [{ tag: 'forge:essences/manipulation' }, { amount: 1000, fluidTag: 'forge:brine' }],
             results: [
                 { item: 'mekanism:dust_lithium', count: 4 },
                 { item: 'emendatusenigmatica:iesnium_dirty_dust', count: 1 }
             ],
+            ingredients: [{ tag: 'forge:essences/manipulation' }, { amount: 1000, fluidTag: 'forge:brine' }],
             heatRequirement: 'superheated',
             id: `${id_prefix}lithium_iesnium`
         },
         {
+            results: [{ item: 'kubejs:mote_of_rebirth', count: 3 }],
             ingredients: [
                 Item.of('minecraft:lingering_potion', { Potion: 'minecraft:strong_regeneration' }).weakNBT().toJson()
             ],
-            results: [{ item: 'kubejs:mote_of_rebirth', count: 3 }],
             heatRequirement: 'superheated',
             id: `${id_prefix}mote_of_rebirth`
         }
     ];
+
+    simple_metals.forEach((metal) => {
+        let secondary_amount = 1;
+        let secondary = metal_properties[metal].oreProcessing.expert_output.secondary;
+
+        if (secondary == 'quartz') {
+            secondary = AlmostUnified.getPreferredItemForTag(`forge:gems/${secondary}`).getId();
+            secondary_amount = 2;
+        } else {
+            secondary = AlmostUnified.getPreferredItemForTag(`mekanism:dirty_dusts/${secondary}`).getId();
+        }
+
+        recipes.push({
+            results: [
+                { item: `emendatusenigmatica:${metal}_dirty_dust`, count: 6 },
+                {
+                    item: secondary,
+                    count: secondary_amount
+                }
+            ],
+            ingredients: [
+                { tag: `create:crushed_ores/${metal}` },
+                { tag: `create:crushed_ores/${metal}` },
+                { tag: `create:crushed_ores/${metal}` },
+                { fluidTag: 'forge:sulfuric_acid', amount: 30 }
+            ],
+            heatRequirement: 'superheated',
+            id: `${id_prefix}${metal}_dirty_dust_from_acid`
+        });
+    });
 
     recipes.forEach((recipe) => {
         recipe.type = 'create:mixing';

--- a/kubejs/server_scripts/expert/recipes/enigmatica/blasting.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/blasting.js
@@ -21,7 +21,7 @@ ServerEvents.recipes((event) => {
         {
             output: `emendatusenigmatica:nickel_ingot`,
             input: `#mekanism:dirty_dusts/nickel`,
-            slag: 'thermal:rich_slag',
+            slag: 'thermal:slag',
             xp: 0.5,
             id_suffix: `nickel_ingot_from_dirty_dust`
         },

--- a/kubejs/server_scripts/expert/recipes/enigmatica/crushing_tiers.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/crushing_tiers.js
@@ -22,6 +22,12 @@ ServerEvents.recipes((event) => {
             input: 'minecraft:end_stone',
             crushing_tier: 4,
             id_suffix: 'crushed_end_stone_from_end_stone'
+        },
+        {
+            outputs: { primary: 'emendatusenigmatica:nickel_dirty_dust' },
+            input: `#mekanism:clumps/nickel`,
+            crushing_tier: metal_properties.nickel.crushing_tier,
+            id_suffix: `nickel_dirty_dust_from_clumps`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/bottling_machine.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/bottling_machine.js
@@ -93,15 +93,41 @@ ServerEvents.recipes((event) => {
             inputs: [{ base_ingredient: { item: 'ae2:charged_certus_quartz_crystal' } }],
             fluid: { amount: 100, tag: 'forge:source' },
             id: `${id_prefix}fluix_crystal`
+        },
+        {
+            results: [
+                { item: 'emendatusenigmatica:iron_dirty_dust', count: 6 },
+                {
+                    item: AlmostUnified.getPreferredItemForTag(
+                        `mekanism:dirty_dusts/${metal_properties.iron.oreProcessing.expert_output.secondary}`
+                    ).getId(),
+                    count: 1
+                }
+            ],
+            inputs: [{ base_ingredient: { tag: `create:crushed_ores/iron` }, count: 3 }],
+            fluid: { tag: 'forge:sulfuric_acid', amount: 30 },
+            id: `${id_prefix}iron_dust_from_redstone_acid`
         }
     ];
 
     simple_metals.forEach((metal) => {
-        let rate = 3;
+        let secondary_amount = 1;
+        let secondary = metal_properties[metal].oreProcessing.expert_output.secondary;
+
+        if (secondary == 'quartz') {
+            secondary = AlmostUnified.getPreferredItemForTag(`forge:gems/${secondary}`).getId();
+            secondary_amount = 2;
+        } else {
+            secondary = AlmostUnified.getPreferredItemForTag(`mekanism:dirty_dusts/${secondary}`).getId();
+        }
+
         recipes.push({
-            results: [{ item: `emendatusenigmatica:${metal}_dirty_dust`, count: 2 * rate }],
-            inputs: [{ base_ingredient: { tag: `create:crushed_ores/${metal}` }, count: 1 * rate }],
-            fluid: { amount: 10 * rate, tag: 'forge:sulfuric_acid' },
+            results: [
+                { item: `emendatusenigmatica:${metal}_dirty_dust`, count: 6 },
+                { item: secondary, count: secondary_amount }
+            ],
+            inputs: [{ base_ingredient: { tag: `create:crushed_ores/${metal}` }, count: 3 }],
+            fluid: { tag: 'forge:sulfuric_acid', amount: 30 },
             id: `${id_prefix}${metal}_dirty_dust_from_acid`
         });
     });

--- a/kubejs/server_scripts/expert/recipes/thermal/bottler.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/bottler.js
@@ -22,18 +22,18 @@ ServerEvents.recipes((event) => {
         }
     ];
 
-    simple_metals.forEach((metal) => {
-        let rate = 3;
-        recipes.push({
-            result: [{ item: `emendatusenigmatica:${metal}_dirty_dust`, count: 2 * rate }],
-            ingredients: [
-                { tag: `create:crushed_ores/${metal}`, count: 1 * rate },
-                { fluid_tag: 'forge:sulfuric_acid', amount: 10 * rate }
-            ],
-            energy: 3000 * rate,
-            id: `${id_prefix}${metal}_dirty_dust_from_acid`
-        });
-    });
+    // simple_metals.forEach((metal) => {
+    //     let rate = 3;
+    //     recipes.push({
+    //         result: [{ item: `emendatusenigmatica:${metal}_dirty_dust`, count: 2 * rate }],
+    //         ingredients: [
+    //             { tag: `create:crushed_ores/${metal}`, count: 1 * rate },
+    //             { fluid_tag: 'forge:sulfuric_acid', amount: 10 * rate }
+    //         ],
+    //         energy: 3000 * rate,
+    //         id: `${id_prefix}${metal}_dirty_dust_from_acid`
+    //     });
+    // });
 
     recipes.forEach((recipe) => {
         recipe.type = 'thermal:bottler';


### PR DESCRIPTION
Nickel should now be available before Iron

![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/2f3821bb-f992-4ead-bd54-da13c7ef7d3b)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/74900091-d2bc-4a51-a546-153695fbf882)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/3d14aef0-1307-4639-a955-647e6f261b95)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/452db92e-8d17-4bf9-8db5-14c976628101)

Bringing back Secondaries from Sulfuric Acid processing, but at a lower rate than originally.
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/09b86200-565e-4928-8073-345d2fe7d369)

Moved similar recipes to Mixing from Filling for Create. 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/33a5289c-0f39-4470-babc-ddc8575ca2a9)
