### PR TITLE
e9e feedback

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -88,21 +88,14 @@
 				"Use the Mixing Cauldron to brew up some Potions of Ancient Knowledge, or any other potions you find interesting. Once brewed, they may be bottled by Right-Clicking the Cauldron with glass bottles."
 			]
 			id: "66585A158F41DE44"
-			rewards: [
-				{
-					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
-					icon: "kubejs:alchemists_delight"
-					id: "7447FA9138D4E94E"
-					player_command: false
-					title: "Alchemist's Delight"
-					type: "command"
-				}
-				{
-					id: "55578A04D9B237EB"
-					item: "hexerei:crystal_ball"
-					type: "item"
-				}
-			]
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "7447FA9138D4E94E"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				icon: "hexerei:mixing_cauldron"
 				id: "4BA040966CFE1DC8"

--- a/config/ftbquests/quests/chapters/powah_expert.snbt
+++ b/config/ftbquests/quests/chapters/powah_expert.snbt
@@ -61,15 +61,15 @@
 		{
 			dependencies: ["484E8107D89F94E0"]
 			description: [
-				"Powah introduces just a few types of machines, but multiple tiers of each. Obtaining higher tiers requires more powerful materials which are made with the Energizing Orb."
+				"Powah introduces just a few types of machines, but multiple tiers of each. Obtaining higher tiers requires more powerful materials which are made with the Resonating Crystal Ball."
 				""
-				"The Orb may be operated by hand or via automation, accepting items from any sort of pipe or conveyance. Once items are inserted, they may not be removed via automation until the craft completes, simplifying automated crafting considerably. Items may be removed by hand at any time, however."
+				"The Crystal Ball may be operated by hand or via automation, accepting items from any sort of pipe or conveyance. Once items are inserted, they may not be removed via automation until the craft completes, simplifying automated crafting considerably. Items may be removed by hand at any time, however."
 				""
-				"Energy for the craft requires Energizing Rods placed around the Orb. These must be placed on some form of energy cable or battery. The rods themselves may be up to six blocks from the Orb and do not require line of sight; they’ll happily shoot their lasers through any block. "
+				"Energy for the craft requires Energizin Rods placed around the Crystal Ball. These must be placed on some form of energy cable or battery. The rods themselves may be up to six blocks from the Crystal Ball and do not require line of sight; they’ll happily shoot their lasers through any block. "
 				""
-				"Rods will automatically link to the nearest Orb when placed but may be re-linked to another Orb manually with a Wrench. Sneak Right-Click the Wrench in the air to change it to Link mode."
+				"Rods will automatically link to the nearest Crystal Ball when placed but may be re-linked to another Crystal Ball manually with a Wrench. Sneak Right-Click the Wrench in the air to change it to Link mode."
 				""
-				"As energy costs increase for higher tier materials, higher tier Rods are recommended to increase the energy delivery rate, though it’s also viable to simply add more Rods. "
+				"As energy costs increase for higher tier materials, higher tier Rods are recommended to increase the energy delivery rate, though it’s also viable to simply add more Rods."
 			]
 			hide_dependency_lines: true
 			icon: "powah:energizing_orb"

--- a/kubejs/client_scripts/lang_modifications.js
+++ b/kubejs/client_scripts/lang_modifications.js
@@ -1005,6 +1005,13 @@ const entries = {
                 normal: 'Energized Steel',
                 expert: 'Orichalcum Ingot'
             }
+        },
+        {
+            key: 'block.powah.energizing_orb',
+            value: {
+                normal: 'Energizing Orb',
+                expert: 'Resonating Crystal Ball'
+            }
         }
     ],
     supplementaries: [

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/ars_nouveau.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/ars_nouveau.js
@@ -66,7 +66,8 @@ ServerEvents.highPriorityData((event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/cnb.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/cnb.js
@@ -31,7 +31,8 @@ ServerEvents.highPriorityData((event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/hexerei.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/hexerei.js
@@ -57,7 +57,8 @@ ServerEvents.highPriorityData((event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/minecraft.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/minecraft.js
@@ -60,31 +60,25 @@ ServerEvents.highPriorityData((event) => {
                 ]
             }
         },
-        // Disabled until I can figure out how to exclude the Occultism spawns from this: Motoko
-        // {
-        //     id: 'blaze',
-        //     name: null,
-        //     chance: 1.0,
-        //     weight: 100,
-        //     quality: 0,
-        //     entities: ['minecraft:blaze'],
-        //     valid_gear_sets: ['#miniboss/blaze'],
-        //     dimensions: [],
-        //     affixed: false,
-        //     nbt: {},
-        //     stats: {
-        //         enchant_chance: 1.0,
-        //         enchantment_levels: [20, 20, 20, 20],
-        //         effects: [{ effect: 'minecraft:strength', amplifier: 0, chance: 1.0 }],
-        //         attribute_modifiers: [
-        //             {
-        //                 attribute: 'minecraft:generic.max_health',
-        //                 operation: 'ADDITION',
-        //                 value: { min: 40, steps: 1, step: 0 }
-        //             }
-        //         ]
-        //     }
-        // },
+        {
+            id: 'blaze',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['minecraft:blaze'],
+            valid_gear_sets: ['#miniboss/empty'],
+            dimensions: [],
+            affixed: false,
+            exclusions: [{ type: 'apotheosis:spawn_type', spawn_types: ['MOB_SUMMONED'] }],
+            nbt: {},
+            stats: {
+                enchant_chance: 1.0,
+                enchantment_levels: [20, 20, 20, 20],
+                effects: [{ effect: 'minecraft:strength', amplifier: 0, chance: 1.0 }],
+                attribute_modifiers: []
+            }
+        },
         {
             id: 'iron_golem',
             name: null,
@@ -430,7 +424,8 @@ ServerEvents.highPriorityData((event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/occultism.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/occultism.js
@@ -345,7 +345,8 @@ ServerEvents.highPriorityData((event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/thermal.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/thermal.js
@@ -10,83 +10,68 @@ enchantment_levels: [50, 30, 120, 40],
 ServerEvents.highPriorityData((event) => {
     const id_prefix = 'apotheosis:minibosses/thermal/';
     const recipes = [
-        // Disabled until I can figure out how to exclude the Occultism spawns from this: Motoko
-        // {
-        //     id: 'blizz',
-        //     name: null,
-        //     chance: 1.0,
-        //     weight: 100,
-        //     quality: 0,
-        //     entities: ['thermal:blizz'],
-        //     valid_gear_sets: ['#miniboss/blizz'],
-        //     dimensions: [],
-        //     affixed: false,
-        //     nbt: {},
-        //     stats: {
-        //         enchant_chance: 1.0,
-        //         enchantment_levels: [20, 20, 20, 20],
-        //         effects: [{ effect: 'cofh_core:panacea', amplifier: 0, chance: 1.0 }],
-        //         attribute_modifiers: [
-        //             {
-        //                 attribute: 'minecraft:generic.max_health',
-        //                 operation: 'ADDITION',
-        //                 value: { min: 40, steps: 1, step: 0 }
-        //             }
-        //         ]
-        //     }
-        // },
-        // {
-        //     id: 'basalz',
-        //     name: null,
-        //     chance: 1.0,
-        //     weight: 100,
-        //     quality: 0,
-        //     entities: ['thermal:basalz'],
-        //     valid_gear_sets: ['#miniboss/basalz'],
-        //     dimensions: [],
-        //     affixed: false,
-        //     nbt: {},
-        //     stats: {
-        //         enchant_chance: 1.0,
-        //         enchantment_levels: [20, 20, 20, 20],
-        //         effects: [{ effect: 'cofh_core:explosion_resistance', amplifier: 0, chance: 1.0 }],
-        //         attribute_modifiers: [
-        //             {
-        //                 attribute: 'minecraft:generic.max_health',
-        //                 operation: 'ADDITION',
-        //                 value: { min: 40, steps: 1, step: 0 }
-        //             }
-        //         ]
-        //     }
-        // },
-        // {
-        //     id: 'blitz',
-        //     name: null,
-        //     chance: 1.0,
-        //     weight: 100,
-        //     quality: 0,
-        //     entities: ['thermal:blitz'],
-        //     valid_gear_sets: ['#miniboss/blitz'],
-        //     dimensions: [],
-        //     affixed: false,
-        //     nbt: {},
-        //     stats: {
-        //         enchant_chance: 1.0,
-        //         enchantment_levels: [20, 20, 20, 20],
-        //         effects: [{ effect: 'cofh_core:lightning_resistance', amplifier: 0, chance: 1.0 }],
-        //         attribute_modifiers: [
-        //             {
-        //                 attribute: 'minecraft:generic.max_health',
-        //                 operation: 'ADDITION',
-        //                 value: { min: 40, steps: 1, step: 0 }
-        //             }
-        //         ]
-        //     }
-        // }
+        {
+            id: 'blizz',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['thermal:blizz'],
+            valid_gear_sets: ['#miniboss/empty'],
+            dimensions: [],
+            affixed: false,
+            exclusions: [{ type: 'apotheosis:spawn_type', spawn_types: ['MOB_SUMMONED'] }],
+            nbt: {},
+            stats: {
+                enchant_chance: 1.0,
+                enchantment_levels: [20, 20, 20, 20],
+                effects: [{ effect: 'cofh_core:panacea', amplifier: 0, chance: 1.0 }],
+                attribute_modifiers: []
+            }
+        },
+        {
+            id: 'basalz',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['thermal:basalz'],
+            valid_gear_sets: ['#miniboss/empty'],
+            dimensions: [],
+            affixed: false,
+            exclusions: [{ type: 'apotheosis:spawn_type', spawn_types: ['MOB_SUMMONED'] }],
+            nbt: {},
+            stats: {
+                enchant_chance: 1.0,
+                enchantment_levels: [20, 20, 20, 20],
+                effects: [{ effect: 'cofh_core:explosion_resistance', amplifier: 0, chance: 1.0 }],
+                attribute_modifiers: []
+            }
+        },
+        {
+            id: 'blitz',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['thermal:blitz'],
+            valid_gear_sets: ['#miniboss/empty'],
+            dimensions: [],
+            affixed: false,
+            exclusions: [{ type: 'apotheosis:spawn_type', spawn_types: ['MOB_SUMMONED'] }],
+            nbt: {},
+            stats: {
+                enchant_chance: 1.0,
+                enchantment_levels: [20, 20, 20, 20],
+                effects: [{ effect: 'cofh_core:lightning_resistance', amplifier: 0, chance: 1.0 }],
+                attribute_modifiers: []
+            }
+        }
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/twilightforest.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/twilightforest.js
@@ -281,7 +281,8 @@ ServerEvents.highPriorityData((event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.exclusions = [{ type: 'apotheosis:nbt', nbt: { Corrupted: true } }];
+        recipe.exclusions ? recipe.exclusions.push(default_exclusions) : (recipe.exclusions = [default_exclusions]);
+
         event.addJson(`${id_prefix}${recipe.id}.json`, recipe);
     });
 });

--- a/kubejs/server_scripts/constants/metal_properties.js
+++ b/kubejs/server_scripts/constants/metal_properties.js
@@ -124,7 +124,7 @@ const metal_properties = {
     },
     aluminum: {
         meltingPoint: 425,
-        crushing_tier: 3,
+        crushing_tier: 2,
         gear: true,
         plate: true,
         rod: true,

--- a/kubejs/server_scripts/constants/minibosses.js
+++ b/kubejs/server_scripts/constants/minibosses.js
@@ -1,0 +1,2 @@
+//priority: 1000
+const default_exclusions = { type: 'apotheosis:nbt', nbt: { Corrupted: true } };

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -128,6 +128,7 @@ ServerEvents.recipes((event) => {
         { id: /hexerei:.*_broom_from_mixing_cauldron/ },
         { id: /hexerei:.*_brush_from_mixing_cauldron/ },
         { id: 'hexerei:pestle_and_mortar_from_mixing_cauldron' },
+        { id: 'hexerei:crystal_ball_from_mixing_cauldron' },
         { id: 'hexerei:warhammer_from_mixing_cauldron' },
         { id: 'hexerei:blood_sigil_from_mixing_cauldron' },
         { id: 'hexerei:herb_jar_from_mixing_cauldron' },

--- a/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
+++ b/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
@@ -265,7 +265,6 @@ ServerEvents.recipes((event) => {
             liquid: { fluid: 'minecraft:lava' },
             liquidOutput: { fluid: 'minecraft:lava' },
             fluidLevelsConsumed: 1000,
-            heatRequirement: 'heated',
             id: `${id_prefix}fiery_ingot`
         },
         {
@@ -897,7 +896,6 @@ ServerEvents.recipes((event) => {
             liquid: { fluid: 'minecraft:lava' },
             liquidOutput: { fluid: 'minecraft:lava' },
             fluidLevelsConsumed: 1000,
-            heatRequirement: 'heated',
             id: 'hexerei:candle_dipper_from_mixing_cauldron'
         },
         {
@@ -953,6 +951,23 @@ ServerEvents.recipes((event) => {
             fluidLevelsConsumed: 500,
             heatRequirement: 'heated',
             id: 'hexerei:large_satchel_from_mixing_cauldron'
+        },
+        {
+            output: 'hexerei:crystal_ball',
+            inputs: [
+                '#forge:storage_blocks/source',
+                'ae2:quartz_vibrant_glass',
+                'ae2:quartz_vibrant_glass',
+                'ae2:quartz_vibrant_glass',
+                'occultism:otherstone_pedestal',
+                'ae2:quartz_vibrant_glass',
+                'ae2:quartz_vibrant_glass',
+                'ae2:quartz_vibrant_glass'
+            ],
+            liquid: { fluid: 'minecraft:lava' },
+            liquidOutput: { fluid: 'minecraft:lava' },
+            fluidLevelsConsumed: 1000,
+            id: `${id_prefix}crystal_ball`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/modularrouters/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/modularrouters/shaped.js
@@ -5,7 +5,7 @@ ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/modularrouters/shaped/';
     const recipes = [
         {
-            output: 'modularrouters:blank_module',
+            output: '3x modularrouters:blank_module',
             pattern: ['AAA', 'ABA', 'CCC'],
             key: {
                 A: 'quark:rainbow_rune',
@@ -15,7 +15,7 @@ ServerEvents.recipes((event) => {
             id: 'modularrouters:blank_module'
         },
         {
-            output: 'modularrouters:blank_upgrade',
+            output: '3x modularrouters:blank_upgrade',
             pattern: ['AAC', 'ABC', ' AC'],
             key: {
                 A: 'quark:rainbow_rune',

--- a/kubejs/server_scripts/expert/recipes/powah/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/powah/shaped.js
@@ -26,9 +26,9 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'powah:energizing_orb',
-            pattern: ['AAA', 'ACA', 'BBB'],
+            pattern: ['CAC', 'BBB'],
             key: {
-                A: 'ae2:quartz_vibrant_glass',
+                A: 'hexerei:crystal_ball',
                 B: 'ae2:sky_stone_block',
                 C: '#forge:essences/manipulation'
             },

--- a/kubejs/server_scripts/expert/recipes/thermal/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/shaped.js
@@ -452,6 +452,26 @@ ServerEvents.recipes((event) => {
                 E: '#forge:essences/fire'
             },
             id: 'thermal:machine_refinery'
+        },
+        {
+            output: '2x thermal:servo_attachment',
+            pattern: [' A ', 'BCB'],
+            key: {
+                A: '#forge:nuggets/copper',
+                B: '#forge:nuggets/tin',
+                C: 'pneumaticcraft:logistics_core'
+            },
+            id: 'thermal:servo_attachment_2'
+        },
+        {
+            output: '2x thermal:turbo_servo_attachment',
+            pattern: [' A ', 'BCB'],
+            key: {
+                A: '#forge:nuggets/signalum',
+                B: '#forge:nuggets/invar',
+                C: 'pneumaticcraft:logistics_core'
+            },
+            id: 'thermal:turbo_servo_attachment_2'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/thermal/smelter.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/smelter.js
@@ -7,189 +7,251 @@ ServerEvents.recipes((event) => {
 
     const recipes = [
         {
-            inputs: ['#forge:dusts/quartz', 'minecraft:obsidian', '#forge:glass/colorless'],
-            outputs: ['2x thermal:obsidian_glass'],
+            ingredients: [
+                { tag: 'forge:dusts/quartz' },
+                { item: 'minecraft:obsidian' },
+                { tag: 'forge:glass/colorless' }
+            ],
+            result: [{ item: 'thermal:obsidian_glass', count: 2 }],
             energy: 4800,
             id: `${id_prefix}obsidian_glass`
         },
         {
-            inputs: ['#forge:dusts/lumium', '2x thermal:obsidian_glass'],
-            outputs: ['2x thermal:lumium_glass'],
+            ingredients: [{ tag: 'forge:dusts/lumium' }, { item: 'thermal:obsidian_glass', count: 2 }],
+            result: [{ item: 'thermal:lumium_glass', count: 2 }],
             energy: 4800,
             id: `${id_prefix}lumium_glass`
         },
         {
-            inputs: ['#forge:dusts/signalum', '2x thermal:obsidian_glass'],
-            outputs: ['2x thermal:signalum_glass'],
+            ingredients: [{ tag: 'forge:dusts/signalum' }, { item: 'thermal:obsidian_glass', count: 2 }],
+            result: [{ item: 'thermal:signalum_glass', count: 2 }],
             energy: 4800,
             id: `${id_prefix}signalum_glass`
         },
         {
-            inputs: ['#forge:dusts/enderium', '2x thermal:obsidian_glass'],
-            outputs: ['2x thermal:enderium_glass'],
+            ingredients: [{ tag: 'forge:dusts/enderium' }, { item: 'thermal:obsidian_glass', count: 2 }],
+            result: [{ item: 'thermal:enderium_glass', count: 2 }],
             energy: 4800,
             id: `${id_prefix}enderium_glass`
         },
         {
-            inputs: ['3x #forge:dusts/copper', '#forge:dusts/tin', '#forge:dusts/redstone'],
-            outputs: [Item.of('emendatusenigmatica:bronze_ingot', 4), 'thermal:slag'],
+            ingredients: [
+                { tag: 'forge:dusts/copper', count: 3 },
+                { tag: 'forge:dusts/tin' },
+                { tag: 'forge:dusts/redstone' }
+            ],
+            result: [{ item: 'emendatusenigmatica:bronze_ingot', count: 4 }, { item: 'thermal:slag' }],
             energy: 2400,
             id: `${id_prefix}bronze_ingot`
         },
         {
-            inputs: ['2x #forge:dusts/silver', '2x #forge:dusts/gold', '#forge:dusts/redstone'],
-            outputs: [Item.of('emendatusenigmatica:electrum_ingot', 4), 'thermal:slag'],
+            ingredients: [
+                { tag: 'forge:dusts/silver', count: 2 },
+                { tag: 'forge:dusts/gold', count: 2 },
+                { tag: 'forge:dusts/redstone' }
+            ],
+            result: [{ item: 'emendatusenigmatica:electrum_ingot', count: 4 }, { item: 'thermal:slag' }],
             energy: 2400,
             id: `${id_prefix}electrum_ingot`
         },
         {
-            inputs: ['2x #forge:dusts/iron', '#forge:dusts/nickel', '2x #forge:dusts/redstone'],
-            outputs: [Item.of('emendatusenigmatica:invar_ingot', 3), '2x thermal:slag'],
+            ingredients: [
+                { tag: 'forge:dusts/iron', count: 2 },
+                { tag: 'forge:dusts/nickel' },
+                { tag: 'forge:dusts/redstone', count: 2 }
+            ],
+            result: [
+                { item: 'emendatusenigmatica:invar_ingot', count: 3 },
+                { item: 'thermal:slag', count: 2 }
+            ],
             energy: 2400,
             id: `${id_prefix}invar_ingot`
         },
         {
-            inputs: ['2x #forge:dusts/nickel', '2x #forge:dusts/copper', '#forge:dusts/redstone'],
-            outputs: [Item.of('emendatusenigmatica:constantan_ingot', 4), 'thermal:slag'],
+            ingredients: [
+                { tag: 'forge:dusts/nickel', count: 2 },
+                { tag: 'forge:dusts/copper', count: 2 },
+                { tag: 'forge:dusts/redstone' }
+            ],
+            result: [{ item: 'emendatusenigmatica:constantan_ingot', count: 4 }, { item: 'thermal:slag' }],
             energy: 2400,
             id: `${id_prefix}constantan_ingot`
         },
         {
-            inputs: ['4x #forge:dusts/aluminum', '#forge:essences/manipulation'],
-            outputs: [Item.of('emendatusenigmatica:signalum_ingot', 4), 'thermal:slag'],
+            ingredients: [{ tag: 'forge:dusts/aluminum', count: 4 }, { tag: 'forge:essences/manipulation' }],
+            result: [{ item: 'emendatusenigmatica:signalum_ingot', count: 4 }, { item: 'thermal:slag' }],
             energy: 2400,
             id: `${id_prefix}signalum_ingot`
         },
         {
-            inputs: [
-                '4x #forge:dusts/constantan',
-                Ingredient.of(['minecraft:glow_berries', 'twilightforest:torchberries'])
-            ],
-            outputs: [Item.of('emendatusenigmatica:lumium_ingot', 4), 'thermal:slag'],
+            ingredients: [{ tag: 'forge:dusts/constantan', count: 4 }, { item: 'minecraft:glow_berries' }],
+            result: [{ item: 'emendatusenigmatica:lumium_ingot', count: 4 }, { item: 'thermal:slag' }],
             energy: 2400,
-            id: `${id_prefix}lumium_ingot`
+            id: `${id_prefix}lumium_ingot_from_glow_berries`
         },
         {
-            inputs: ['modularrouters:augment_core', '2x #forge:essences/water', '#forge:gems/source'],
-            outputs: ['thermal:machine_efficiency_augment'],
+            ingredients: [{ tag: 'forge:dusts/constantan', count: 4 }, { item: 'twilightforest:torchberries' }],
+            result: [{ item: 'emendatusenigmatica:lumium_ingot', count: 4 }, { item: 'thermal:slag' }],
+            energy: 2400,
+            id: `${id_prefix}lumium_ingot_from_torchberries`
+        },
+        {
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { tag: 'forge:essences/water', count: 2 },
+                { tag: 'forge:gems/source' }
+            ],
+            result: [{ item: 'thermal:machine_efficiency_augment' }],
             energy: 10000,
             id: `${id_prefix}machine_efficiency_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '2x #forge:essences/fire', '#forge:gems/source'],
-            outputs: ['thermal:machine_speed_augment'],
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { tag: 'forge:essences/fire', count: 2 },
+                { tag: 'forge:gems/source' }
+            ],
+            result: [{ item: 'thermal:machine_speed_augment' }],
             energy: 10000,
             id: `${id_prefix}machine_speed_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '2x #forge:essences/air', 'powah:capacitor_basic_large'],
-            outputs: ['thermal:rf_coil_augment'],
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { tag: 'forge:essences/air', count: 2 },
+                { item: 'powah:capacitor_basic_large' }
+            ],
+            result: [{ item: 'thermal:rf_coil_augment' }],
             energy: 10000,
             id: `${id_prefix}rf_coil_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '2x #forge:essences/fire', 'powah:capacitor_basic_large'],
-            outputs: ['thermal:rf_coil_xfer_augment'],
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { tag: 'forge:essences/fire', count: 2 },
+                { item: 'powah:capacitor_basic_large' }
+            ],
+            result: [{ item: 'thermal:rf_coil_xfer_augment' }],
             energy: 10000,
             id: `${id_prefix}rf_coil_xfer_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '2x #forge:essences/water', 'powah:capacitor_basic_large'],
-            outputs: ['thermal:rf_coil_storage_augment'],
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { tag: 'forge:essences/water', count: 2 },
+                { item: 'powah:capacitor_basic_large' }
+            ],
+            result: [{ item: 'thermal:rf_coil_storage_augment' }],
             energy: 10000,
             id: `${id_prefix}rf_coil_storage_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', 'thermal:fluid_cell_frame'],
-            outputs: ['thermal:fluid_tank_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { item: 'thermal:fluid_cell_frame' }],
+            result: [{ item: 'thermal:fluid_tank_augment' }],
             energy: 10000,
             id: `${id_prefix}fluid_tank_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '4x #forge:fabrics/infused'],
-            outputs: ['thermal:machine_output_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { tag: 'forge:fabrics/infused', count: 4 }],
+            result: [{ item: 'thermal:machine_output_augment' }],
             energy: 10000,
             id: `${id_prefix}machine_output_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '#forge:gems/infused_diamond'],
-            outputs: ['thermal:machine_catalyst_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { tag: 'forge:gems/infused_diamond' }],
+            result: [{ item: 'thermal:machine_catalyst_augment' }],
             energy: 10000,
             id: `${id_prefix}machine_catalyst_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '4x #forge:gems/quartz'],
-            outputs: ['thermal:area_radius_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { tag: 'forge:gems/quartz', count: 4 }],
+            result: [{ item: 'thermal:area_radius_augment' }],
             energy: 10000,
             id: `${id_prefix}area_radius_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', 'pneumaticcraft:logistics_core'],
-            outputs: ['thermal:machine_cycle_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { item: 'pneumaticcraft:logistics_core' }],
+            result: [{ item: 'thermal:machine_cycle_augment' }],
             energy: 10000,
             id: `${id_prefix}machine_cycle_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', '#forge:storage_blocks/knightmetal'],
-            outputs: ['thermal:machine_null_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { tag: 'forge:storage_blocks/knightmetal' }],
+            result: [{ item: 'thermal:machine_null_augment' }],
             energy: 10000,
             id: `${id_prefix}machine_null_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', 'ars_nouveau:potion_flask_amplify'],
-            outputs: ['thermal:potion_amplifier_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { item: 'ars_nouveau:potion_flask_amplify' }],
+            result: [{ item: 'thermal:potion_amplifier_augment' }],
             energy: 10000,
             id: `${id_prefix}potion_amplifier_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', 'ars_nouveau:potion_flask_extend_time'],
-            outputs: ['thermal:potion_duration_augment'],
+            ingredients: [{ item: 'modularrouters:augment_core' }, { item: 'ars_nouveau:potion_flask_extend_time' }],
+            result: [{ item: 'thermal:potion_duration_augment' }],
             energy: 10000,
             id: `${id_prefix}potion_duration_augment`
         },
         {
-            inputs: [
-                'modularrouters:augment_core',
-                'immersiveengineering:component_electronic',
-                'immersiveengineering:coil_mv'
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { item: 'immersiveengineering:component_electronic' },
+                { item: 'immersiveengineering:coil_mv' }
             ],
-            outputs: ['thermal:dynamo_throttle_augment'],
+            result: [{ item: 'thermal:dynamo_throttle_augment' }],
             energy: 10000,
             id: `${id_prefix}dynamo_throttle_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', 'thermal:energy_cell_frame', '4x quark:rainbow_rune'],
-            outputs: ['thermal:dynamo_output_augment'],
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { item: 'thermal:energy_cell_frame' },
+                { item: 'quark:rainbow_rune', count: 4 }
+            ],
+            result: [{ item: 'thermal:dynamo_output_augment' }],
             energy: 10000,
             id: `${id_prefix}dynamo_output_augment`
         },
         {
-            inputs: ['modularrouters:augment_core', 'minecraft:lodestone', '4x #forge:gems/source'],
-            outputs: ['thermal:dynamo_fuel_augment'],
+            ingredients: [
+                { item: 'modularrouters:augment_core' },
+                { item: 'minecraft:lodestone' },
+                { tag: 'forge:gems/source', count: 4 }
+            ],
+            result: [{ item: 'thermal:dynamo_fuel_augment' }],
             energy: 10000,
             id: `${id_prefix}dynamo_fuel_augment`
         },
         {
-            inputs: ['minecraft:netherite_scrap', '4x #forge:ingots/soul_steel'],
-            outputs: [`4x minecraft:netherite_ingot`],
+            ingredients: [{ item: 'minecraft:netherite_scrap' }, { tag: 'forge:ingots/soul_steel', count: 4 }],
+            result: [{ item: `minecraft:netherite_ingot`, count: 4 }],
             energy: 20000,
             id: `${id_prefix}netherite_ingot`
         },
         {
-            inputs: ['pneumaticcraft:logistics_core', 'ae2:singularity', 'mekanism:teleportation_core'],
-            outputs: ['2x kubejs:energetic_transference_matrix'],
+            ingredients: [
+                { item: 'pneumaticcraft:logistics_core' },
+                { item: 'ae2:singularity' },
+                { item: 'mekanism:teleportation_core' }
+            ],
+            result: [{ item: `kubejs:energetic_transference_matrix`, count: 2 }],
             energy: 8000,
             id: `${id_prefix}energetic_transference_matrix`
         },
         {
-            inputs: ['#forge:gems/spirit_attuned', '4x #forge:ingots/knightmetal'],
-            outputs: ['4x naturesaura:depth_ingot'],
+            ingredients: [{ tag: 'forge:gems/spirit_attuned' }, { tag: 'forge:ingots/knightmetal', count: 4 }],
+            result: [{ item: `naturesaura:depth_ingot`, count: 4 }],
             energy: 8000,
             id: `${id_prefix}depth_ingot`
         },
         {
-            inputs: ['4x thermal:rubber', '#forge:essences/fire', '#forge:essences/water'],
-            outputs: ['4x thermal:cured_rubber'],
+            ingredients: [
+                { item: 'thermal:rubber', count: 4 },
+                { tag: 'forge:essences/fire' },
+                { tag: 'forge:essences/water' }
+            ],
+            result: [{ item: `thermal:cured_rubber`, count: 4 }],
             energy: 1000,
             id: `${id_prefix}cured_rubber`
         }
@@ -197,8 +259,6 @@ ServerEvents.recipes((event) => {
 
     recipes.forEach((recipe) => {
         recipe.type = 'thermal:smelter';
-        recipe.ingredients = recipe.inputs.map((input) => Ingredient.of(input).toJson());
-        recipe.result = recipe.outputs.map((output) => Item.of(output).toJson());
         event.custom(recipe).id(recipe.id);
     });
 });


### PR DESCRIPTION
Nerf Blitz/Blaze/Basalz/Blizz
Reactive armor is gone. Health is reduce. Potion effect remains.

Refactor thermal smelter script because it is apparently an issue on servers and because it's all going to break come next kubejs update anyway...

Increase yields for modular routers items
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/4126ef21-b73b-4475-8170-234d11ab76de)

![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/b9f363aa-247f-4f59-a527-8a8f29f65f89)

Servo: 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/46c65acd-8575-49a0-9655-c66cade981f1)

Turbo Servo: 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/9f279c55-90b9-4197-b51f-dc98debfbee6)


Crystal Ball
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/431197a9-662e-47cf-8fe9-ba4819e37629)

Energizing Orb
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/9f2ce823-83bf-4d59-a1a0-1bbed7e9c8aa)

Aluminum moved down to tier 2 crushing so orichalcum can actually be crafted
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/242960f5-f9e1-46b0-a74c-14b1f0d6184d)
