### PR TITLE
Potion adjustments

### DIFF
--- a/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
@@ -30,8 +30,36 @@
 			}]
 			shape: "gear"
 			tasks: [{
-				id: "4C0C28C6DB286E4B"
-				item: "ars_nouveau:novice_spell_book"
+				id: "5F9E4E6B1B0F02DE"
+				item: {
+					Count: 1b
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "ars_elemental:yellow_archwood_sapling"
+							}
+							{
+								Count: 1b
+								id: "ars_nouveau:blue_archwood_sapling"
+							}
+							{
+								Count: 1b
+								id: "ars_nouveau:purple_archwood_sapling"
+							}
+							{
+								Count: 1b
+								id: "ars_nouveau:green_archwood_sapling"
+							}
+							{
+								Count: 1b
+								id: "ars_nouveau:red_archwood_sapling"
+							}
+						]
+					}
+				}
+				title: "Archwood Saplings"
 				type: "item"
 			}]
 			title: "Ars Nouveau"

--- a/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
@@ -67,19 +67,11 @@
 			description: [
 				"Source may be found in any living thing, so it should come as no surprise that it may be condensed from most living matter. In a natural cycle, the Source contained in the living is simply passed around from plant to animal and back. A nearby Sourcelink, however, may be used to re-direct that ephemeral dew into specially prepared Source Jars, preserving it for later use."
 				""
-				"Each Sourcelink has its own requirements which are covered in detail in the Worn Notebook. They’re all useful in their own way, often the best choice is dictated by what other activities are already happening in an area."
+				"Each Sourcelink has its own requirements which are covered in detail in the Worn Notebook. "
 				""
-				"● Agronomic absorbs source from growing plants. Each time a nearby plant progresses a growth stage, some Source is produced. Certain magical plants produce more Source."
+				"● Alchemical Source Links re-absorb the condensed Source present in Potions. Any beneficial spell stored in an adjacent Potion Jar will be absorbed, producing Source. More is produced from stronger potions."
 				""
-				"● Alchemical re-absorbs the condensed Source present in Potions. Any beneficial spell stored in an adjacent Potion Jar will be absorbed, producing Source. More is produced from stronger potions."
-				""
-				"● Mycelial consumes food items placed into adjacent Pedestals. Though all food is rich in Source, those produced from Sourceberries tend to contain the most. "
-				""
-				"● Vitalic absorbs the life-force of creatures dying nearby. "
-				""
-				"● Volcanic consumes most burnables from adjacent Pedestals. Coal, long fossilized trees, produces a small amount while Blazing Archwood logs produce more sizeable quantities. "
-				""
-				"● Fluid absorbs certain liquids from tanks placed below it, converting it into Source at different rates. "
+				"● Fluid Source Links absorb certain liquids from tanks placed below it, converting them into Source at different rates. "
 			]
 			icon: "emendatusenigmatica:source_gem"
 			id: "302C5405A92ABA2B"
@@ -134,7 +126,7 @@
 						]
 					}
 				}
-				title: "Sourcelinks"
+				title: "Source Links"
 				type: "item"
 			}]
 			x: -5.5d
@@ -184,6 +176,14 @@
 			]
 			hide_dependency_lines: true
 			id: "61D89161FF1433AC"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
+				icon: "kubejs:rare_lootbox"
+				id: "489E57E94749C830"
+				player_command: false
+				title: "Rare Ars Nouveau Loot Box"
+				type: "command"
+			}]
 			subtitle: "Jousting Snails"
 			tasks: [{
 				id: "178E6CCD5BBB06AE"
@@ -553,18 +553,11 @@
 				type: "command"
 			}]
 			subtitle: "Wyrd Sisters"
-			tasks: [
-				{
-					id: "1F0E715353FA7539"
-					item: "ars_nouveau:wixie_charm"
-					type: "item"
-				}
-				{
-					id: "4A01A83E8357A13D"
-					item: "minecraft:cauldron"
-					type: "item"
-				}
-			]
+			tasks: [{
+				id: "1F0E715353FA7539"
+				item: "ars_nouveau:wixie_charm"
+				type: "item"
+			}]
 			x: -7.0d
 			y: -0.5d
 		}
@@ -889,7 +882,7 @@
 			y: 1.0d
 		}
 		{
-			dependencies: ["4CFBDE9FB821CFB6"]
+			dependencies: ["4FFD31414D5F69E6"]
 			description: [
 				"Going somewhere? "
 				""
@@ -899,6 +892,7 @@
 				""
 				"Alternatively, a portal may be built using any type of Sourcestone in a rectangular shape.  Place a filled Source Jar nearby and toss a bound Warp Scroll through the frame to ignite it, linking it to the coordinates from the scroll. Items, mobs, even spells may pass through these portals, though they are incapable of crossing between dimensions. "
 			]
+			hide_dependency_lines: true
 			id: "524A6B28242AA5B8"
 			rewards: [{
 				count: 8
@@ -1294,28 +1288,39 @@
 			hide_dependency_lines: true
 			icon: "ars_nouveau:imbuement_chamber"
 			id: "4197331BEFC9523D"
-			rewards: [{
-				id: "05D0688D89E97282"
-				item: {
-					Count: 1b
-					id: "ars_nouveau:dowsing_rod"
-					tag: {
-						Damage: 0
+			rewards: [
+				{
+					id: "05D0688D89E97282"
+					item: {
+						Count: 1b
+						id: "ars_nouveau:dowsing_rod"
+						tag: {
+							Damage: 0
+						}
 					}
+					type: "item"
 				}
-				type: "item"
-			}]
+				{
+					count: 2
+					id: "3B8874244924D7CC"
+					item: "emendatusenigmatica:source_block"
+					type: "item"
+				}
+			]
 			shape: "hexagon"
 			subtitle: "Like Sweet Morning Dew"
 			tasks: [
 				{
-					id: "51BB03B7812E7421"
-					item: "ars_nouveau:imbuement_chamber"
-					type: "item"
+					icon: "ars_nouveau:imbuement_chamber"
+					id: "284734CBDFB5F1C8"
+					observe_type: 0
+					timer: 0L
+					to_observe: "ars_nouveau:imbuement_chamber"
+					type: "observation"
 				}
 				{
 					icon: "emendatusenigmatica:source_gem"
-					id: "62D003778D2E6D62"
+					id: "05D5F1C15D930952"
 					item: {
 						Count: 1b
 						id: "itemfilters:tag"

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -193,6 +193,7 @@
 			id: "66A59B3CD77FB54A"
 			min_width: 300
 			rewards: [{
+				count: 3
 				id: "7BE2B86F33268C1A"
 				item: {
 					Count: 1b
@@ -767,14 +768,21 @@
 			]
 			icon: "create:blaze_burner"
 			id: "5038FC4A51F51F31"
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
-				icon: "kubejs:sorcerers_delight"
-				id: "29AD14E62D652876"
-				player_command: false
-				title: "Sorcerer's Delight"
-				type: "command"
-			}]
+			rewards: [
+				{
+					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
+					icon: "kubejs:sorcerers_delight"
+					id: "29AD14E62D652876"
+					player_command: false
+					title: "Sorcerer's Delight"
+					type: "command"
+				}
+				{
+					id: "118314732B168F3D"
+					item: "createaddition:straw"
+					type: "item"
+				}
+			]
 			tasks: [
 				{
 					id: "377114D7550BC0D8"
@@ -865,6 +873,14 @@
 			hide_dependency_lines: true
 			icon: "ars_nouveau:novice_spell_book"
 			id: "370C40BCC3A6A055"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
+				icon: "kubejs:sorcerers_delight"
+				id: "181F9F12E4654AC3"
+				player_command: false
+				title: "Sorcerer's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [
 				{
@@ -1643,6 +1659,12 @@
 				"Undoubtedly, some can be found in the ruins of their homes or within the ore hills they’ve left behind. "
 			]
 			id: "11AB47232D9F5D6D"
+			rewards: [{
+				count: 2
+				id: "477B37812787254C"
+				item: "emendatusenigmatica:source_block"
+				type: "item"
+			}]
 			tasks: [{
 				id: "2C7B6B3C361553D4"
 				item: "emendatusenigmatica:source_gem"
@@ -2011,6 +2033,14 @@
 			]
 			hide_dependency_lines: true
 			id: "1B214D5A289CD17A"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
+				icon: "kubejs:sorcerers_delight"
+				id: "13E73AB24BADDF67"
+				player_command: false
+				title: "Sorcerer's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [{
 				icon: {
@@ -2047,6 +2077,14 @@
 			]
 			hide_dependency_lines: true
 			id: "15C6FD1F5AD1C530"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
+				icon: "kubejs:sorcerers_delight"
+				id: "6D4844BFC44CD5D5"
+				player_command: false
+				title: "Sorcerer's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [{
 				icon: {
@@ -2079,6 +2117,14 @@
 			]
 			hide_dependency_lines: true
 			id: "7376270A390D6A3C"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
+				icon: "kubejs:sorcerers_delight"
+				id: "5C504E7B50DF72CA"
+				player_command: false
+				title: "Sorcerer's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "633962F5F4F1548E"

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -1943,6 +1943,14 @@
 				"Be sure to spend some time experimenting with the Spell Book, as it is easily one of the most powerful weapons in the hands of an experienced witch. "
 			]
 			id: "508748A195DE2C10"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "46B73E0A24DE5D55"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "6D5621B8BF6A9C18"

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -828,7 +828,7 @@
 					type: "item"
 				}
 			]
-			x: -1.0d
+			x: -2.0d
 			y: 2.0d
 		}
 		{
@@ -843,7 +843,7 @@
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
-			shape: "diamond"
+			shape: "hexagon"
 			tasks: [
 				{
 					id: "156E6D2ED289EC8F"
@@ -1652,10 +1652,7 @@
 			y: -3.0d
 		}
 		{
-			dependencies: [
-				"201EF7C650717118"
-				"16694CCD304B9745"
-			]
+			dependencies: ["668B76A0085B4054"]
 			description: [
 				"Restoring the Tree of Life to its full glory will be no easy task. Use the knowledge obtained thus far to grow the seedling. With time and sacrifice, it will grow stronger. "
 				""
@@ -1676,7 +1673,7 @@
 				}
 				type: "item"
 			}]
-			shape: "diamond"
+			shape: "hexagon"
 			tasks: [
 				{
 					id: "439B5ADE18EE0912"
@@ -1695,38 +1692,6 @@
 			y: 5.0d
 		}
 		{
-			dependencies: ["668B76A0085B4054"]
-			id: "201EF7C650717118"
-			shape: "diamond"
-			tasks: [{
-				id: "77AAD1F4C77CD9DF"
-				item: "emendatusenigmatica:sky_ingot"
-				type: "item"
-			}]
-			x: -3.0d
-			y: 4.5d
-		}
-		{
-			dependencies: ["668B76A0085B4054"]
-			id: "16694CCD304B9745"
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
-				icon: "kubejs:scavengers_delight"
-				id: "3397636DF871DB89"
-				player_command: false
-				title: "Scavenger's Delight"
-				type: "command"
-			}]
-			shape: "diamond"
-			tasks: [{
-				id: "719947AB9775C6CC"
-				item: "ae2:sky_dust"
-				type: "item"
-			}]
-			x: -4.0d
-			y: 4.5d
-		}
-		{
 			dependencies: ["347A644441BCF449"]
 			description: ["Often found clustered in with Tin ores, Quartz may be extracted occasionally when grinding the ore with better tools, such as the Mill. "]
 			id: "5B7806FED7D58329"
@@ -1743,7 +1708,7 @@
 				item: "minecraft:quartz"
 				type: "item"
 			}]
-			x: -6.0d
+			x: -5.0d
 			y: 2.0d
 		}
 		{

--- a/config/ftbquests/quests/chapters/chapter_two.snbt
+++ b/config/ftbquests/quests/chapters/chapter_two.snbt
@@ -80,6 +80,14 @@
 		{
 			dependencies: ["55C6945D58D77AB6"]
 			id: "4C676E7D2BA75DE4"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "34E9AE2633A6559C"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "47352920219144B1"
 				item: "kubejs:gloaming_catalyst"
@@ -91,6 +99,11 @@
 		{
 			dependencies: ["4C676E7D2BA75DE4"]
 			id: "71D9A268FF98E954"
+			rewards: [{
+				id: "13F50F2CE1F91DC0"
+				item: "rftoolsbase:infused_diamond"
+				type: "item"
+			}]
 			tasks: [{
 				id: "4FF05D947BDCBD0C"
 				item: "kubejs:spirit_of_devotion"
@@ -125,6 +138,14 @@
 				"Just the same, the processes of cleansing this debris into a useful ingot is not for the feint of heart. "
 			]
 			id: "77E8DD38A379F9C7"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "2275D9F976F77BDF"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				icon: "minecraft:netherite_ingot"
 				id: "55E4F11D8C8357A5"
@@ -145,6 +166,14 @@
 				"Celestial Gold, blessed by the gods themselves, would ring out across the dimensions like a clear bell on a calm day. They’d never resist the chance to corrupt something so sacred. "
 			]
 			id: "39B2F84EBDC27AA3"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "1E6AE784E9612FE8"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				icon: "emendatusenigmatica:tainted_gold_ingot"
 				id: "4241691B8FE4293D"
@@ -164,6 +193,14 @@
 		{
 			dependencies: ["00B21E64DEFACB40"]
 			id: "31E4C2A162D7497C"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "4C9ACBB578AFC307"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "2D56C518D77625DD"
 				item: "ars_nouveau:enchanting_apparatus"
@@ -233,6 +270,14 @@
 		{
 			dependencies: ["1D0AA79380E87E57"]
 			id: "7563E41DBF4FD286"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "1B24E64E968AA545"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "6D78A382292EF627"
 				item: "industrialforegoing:machine_frame_simple"
@@ -248,6 +293,14 @@
 			]
 			icon: "industrialforegoing:ore_laser_base"
 			id: "17F735810850C368"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "27B8D639195825E7"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [
 				{
 					id: "5F0411E4A7C69564"
@@ -277,6 +330,14 @@
 			dependencies: ["7465284C82512CF1"]
 			icon: "industrialforegoing:fluid_laser_base"
 			id: "5503E132D9D02EF8"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "3AAF8D915008D323"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [
 				{
 					id: "6FE9FBFD8C2D21EA"
@@ -305,6 +366,14 @@
 		{
 			dependencies: ["31E4C2A162D7497C"]
 			id: "6044FE23384692A5"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "11C12981BC558B2F"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "0B70A4972A7F691F"
 				item: "create:crushing_wheel"
@@ -319,6 +388,14 @@
 				"6E239ECBE33DFA36"
 			]
 			id: "606F79DAEB15E85B"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "7A03B91B11415840"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "1A90312A5DCEA90B"
 				item: "spirit:soul_steel_ingot"
@@ -330,6 +407,14 @@
 		{
 			dependencies: ["606F79DAEB15E85B"]
 			id: "507A68CE5D41C4C2"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "208C36FB1E415323"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "0D888CFF2F834C92"
 				item: "industrialforegoing:machine_frame_advanced"
@@ -341,6 +426,14 @@
 		{
 			dependencies: ["17F735810850C368"]
 			id: "126F4E070F219A8B"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "43BF2A66732C89E4"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "2CF76301E00C267D"
 				item: "spirit:soul_powder"
@@ -384,6 +477,14 @@
 		{
 			dependencies: ["49159D9F94B7006C"]
 			id: "767A379B00DCA2E0"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "18698AF64B9CA533"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				icon: "minecraft:iron_ingot"
 				id: "1558A342DAD1935D"
@@ -405,6 +506,14 @@
 			description: ["Supplying enough heat to work with Iron directly has proved difficult until now. With a magically enhanced blast furnace and Blazing Crystals as fuel, it should prove more feasible."]
 			icon: "immersiveengineering:advanced_blast_furnace"
 			id: "2BA70920EA1ED0A8"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "212FE78B53835607"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "79ABD0D7EFB8D300"
 				item: "immersiveengineering:blastbrick_reinforced"
@@ -422,6 +531,14 @@
 				"Projectile > Crush > Sensitive "
 			]
 			id: "1D0AA79380E87E57"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "1BBB80CE7BEB69CF"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "5C129E4F6EAC8C83"
 				item: "pneumaticcraft:ingot_iron_compressed"
@@ -443,6 +560,14 @@
 			]
 			icon: "immersiveengineering:light_engineering"
 			id: "2C43443DCFFF65F4"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "04BACC81CA01141B"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [
 				{
 					id: "05A605FCDAEBD972"
@@ -470,6 +595,14 @@
 				"● Crusher"
 			]
 			id: "15F56E72212629FB"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "42238537475907E4"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "0154E90B21C27B44"
 				item: "immersiveengineering:heavy_engineering"
@@ -482,6 +615,14 @@
 		{
 			dependencies: ["738DA69FFF6516FA"]
 			id: "21C352EEFEB25365"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "6F1EDCAD415A69B3"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "4027AFF2F762B0D1"
 				item: "kubejs:energetic_transference_matrix"
@@ -493,6 +634,14 @@
 		{
 			dependencies: ["15F56E72212629FB"]
 			id: "7465284C82512CF1"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "4E55A7B7ECBDEA8B"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "25E1CC6FE74A1DFB"
 				item: "pneumaticcraft:assembly_controller"
@@ -504,6 +653,14 @@
 		{
 			dependencies: ["0C0A98C6DD871BD3"]
 			id: "49159D9F94B7006C"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "79ACAFF79994FD61"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "7667047356862670"
 				item: "mekanism:metallurgic_infuser"
@@ -524,6 +681,12 @@
 				"While in the Bumblezone, Right-Click the Honey Compass in the air to attune it to the Cell Maze."
 			]
 			id: "57861ABDB35ED555"
+			rewards: [{
+				count: 16
+				id: "7171199016FE9E99"
+				item: "minecraft:honey_bottle"
+				type: "item"
+			}]
 			shape: "hexagon"
 			tasks: [{
 				id: "707735727FE79FB9"
@@ -648,6 +811,14 @@
 		{
 			dependencies: ["60324503ED7AC4C1"]
 			id: "00B21E64DEFACB40"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "23B342C9B1B2B79C"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "01AF1B57146069F1"
 				item: "powah:steel_energized"
@@ -659,6 +830,14 @@
 		{
 			dependencies: ["00B21E64DEFACB40"]
 			id: "738DA69FFF6516FA"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "5EF326CA11F451A6"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "60BB72446E4D266C"
 				item: "occultism:spirit_attuned_gem"
@@ -670,6 +849,14 @@
 		{
 			dependencies: ["2BA70920EA1ED0A8"]
 			id: "0C0A98C6DD871BD3"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "6E97F4196A474693"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "0F59CD79EA51B378"
 				item: "kubejs:crude_iron_ingot"
@@ -724,6 +911,14 @@
 		{
 			dependencies: ["49159D9F94B7006C"]
 			id: "4A7EC5D11F20F2B7"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "220BD7C24AB55C46"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "76E4EFCD4200B779"
 				item: "emendatusenigmatica:steel_ingot"
@@ -735,6 +930,14 @@
 		{
 			dependencies: ["767A379B00DCA2E0"]
 			id: "2BE91F37CE010984"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "47F50316632E7DC7"
+				player_command: false
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			tasks: [{
 				id: "4CCF04553715833F"
 				item: "emendatusenigmatica:invar_ingot"
@@ -819,6 +1022,14 @@
 			hide_dependency_lines: true
 			icon: "ae2:controller"
 			id: "330C200F0F0243FC"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "72393E06B7289A9F"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [
 				{
@@ -850,6 +1061,14 @@
 			description: ["Known for their strength and endurance, Basalz will work tirelessly to power Create machinery if properly motived. "]
 			icon: "createaddition:electric_motor"
 			id: "1FDD6F9166A33F8D"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
+				icon: "kubejs:alchemists_delight"
+				id: "1510DA7F74A2CBA0"
+				player_command: false
+				title: "Alchemist's Delight"
+				type: "command"
+			}]
 			tasks: [
 				{
 					id: "04B03547884EC0AA"

--- a/config/ftbquests/quests/chapters/chapter_two.snbt
+++ b/config/ftbquests/quests/chapters/chapter_two.snbt
@@ -906,6 +906,69 @@
 			x: 6.5d
 			y: 0.0d
 		}
+		{
+			dependencies: ["738DA69FFF6516FA"]
+			description: [
+				"With heightened spell casting ability comes the ability to improve some automation through Spell Turrets.  "
+				""
+				"As a practical example, the following spell form will allow a turret to pull a standard potion from an adjacent Potion Jar, convert it to Lingering and throw it where the projectile lands."
+				""
+				"&5Projectile&r > &aInfuse&r > &6Extend Time&r"
+				""
+				"These lingering potions will work exactly as their crafted variety for the purpose of running a Lingering Absorber without the need to craft beyond the base potion. "
+			]
+			hide_dependency_lines: true
+			id: "7619B458914F41FF"
+			rewards: [{
+				id: "58831BD248E42B45"
+				item: {
+					Count: 1b
+					id: "ars_nouveau:spell_parchment"
+					tag: {
+						"ars_nouveau:caster": {
+							current_slot: 0
+							flavor: ""
+							hidden_recipe: ""
+							is_hidden: 0b
+							spell_count: 1
+							spells: {
+								spell0: {
+									name: "Lingering Potions"
+									recipe: {
+										part0: "ars_nouveau:glyph_projectile"
+										part1: "ars_nouveau:glyph_infuse"
+										part2: "ars_nouveau:glyph_extend_time"
+										size: 3
+									}
+									sound: {
+										pitch: 0.01f
+										soundTag: {
+											id: "ars_nouveau:tempestry_family"
+										}
+										volume: 0.4f
+									}
+									spellColor: {
+										b: 255
+										g: 71
+										r: 1
+										type: "ars_nouveau:rainbow"
+									}
+								}
+							}
+						}
+					}
+				}
+				type: "item"
+			}]
+			shape: "hexagon"
+			tasks: [{
+				id: "3716441EC6ACD043"
+				item: "ars_nouveau:timer_spell_turret"
+				type: "item"
+			}]
+			x: 6.5d
+			y: 1.0d
+		}
 	]
 	title: "Chapter Two"
 }

--- a/config/ftbquests/quests/chapters/mekanism_expert.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_expert.snbt
@@ -43,22 +43,14 @@
 			hide_dependency_lines: true
 			id: "13762022DEE4BEC5"
 			min_width: 300
-			rewards: [
-				{
-					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
-					icon: "kubejs:rare_lootbox"
-					id: "03D6AC51756CA1AD"
-					player_command: false
-					title: "Rare Mekanism Loot Box"
-					type: "command"
-				}
-				{
-					id: "77AD7E7DB9CF1EEF"
-					item: "mekanism:steel_casing"
-					title: "Steel Casing"
-					type: "item"
-				}
-			]
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
+				icon: "kubejs:rare_lootbox"
+				id: "03D6AC51756CA1AD"
+				player_command: false
+				title: "Rare Mekanism Loot Box"
+				type: "command"
+			}]
 			subtitle: "Advanced Metallurgy"
 			tasks: [{
 				id: "367A53ACB8A3AECB"
@@ -94,7 +86,7 @@
 				type: "item"
 			}]
 			x: 5.5d
-			y: -0.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["094FAB57D8E3D2F6"]
@@ -107,30 +99,14 @@
 			]
 			hide_dependency_lines: true
 			id: "5EC7CA1A86435B30"
-			rewards: [
-				{
-					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
-					icon: "kubejs:rare_lootbox"
-					id: "131BF3970989B404"
-					player_command: false
-					title: "Rare Mekanism Loot Box"
-					type: "command"
-				}
-				{
-					count: 4
-					id: "2A96EA3BE19E6B08"
-					item: "mekanism:enriched_redstone"
-					title: "Enriched Redstone"
-					type: "item"
-				}
-				{
-					count: 8
-					id: "527979FF09FCCA75"
-					item: "mekanism:enriched_carbon"
-					title: "Enriched Carbon"
-					type: "item"
-				}
-			]
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
+				icon: "kubejs:rare_lootbox"
+				id: "131BF3970989B404"
+				player_command: false
+				title: "Rare Mekanism Loot Box"
+				type: "command"
+			}]
 			subtitle: "Put One In The Chamber"
 			tasks: [{
 				id: "5F5EE2F551F7913B"
@@ -166,7 +142,7 @@
 				type: "item"
 			}]
 			x: 7.5d
-			y: -0.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["094FAB57D8E3D2F6"]
@@ -187,13 +163,13 @@
 				item: "mekanism:pressurized_reaction_chamber"
 				type: "item"
 			}]
-			x: 6.5d
+			x: 7.0d
 			y: 1.0d
 		}
 		{
 			dependencies: ["094FAB57D8E3D2F6"]
 			description: [
-				"You had a stockpile of Uranium, right? Yeah. You're going to need a lot to build this structure, which is used for generating Antimatter from Nuclear Waste."
+				"By infusing Pandemonium with incredible amounts of magical energies, it may be refined into a material with potent transmutational properties: Aetherium."
 				""
 				"Two ports with Supercharged Coils will accept power input. The other two ports will be used for inputting waste and outputting antimatter."
 				""
@@ -205,23 +181,14 @@
 			icon: "mekanism:sps_casing"
 			id: "3F0DE5664216AD01"
 			min_width: 275
-			rewards: [
-				{
-					count: 64
-					id: "48465C411786E326"
-					item: "emendatusenigmatica:raw_uranium"
-					title: "Uranium Ore"
-					type: "item"
-				}
-				{
-					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
-					icon: "kubejs:legendary_lootbox"
-					id: "2A335028425C54BC"
-					player_command: false
-					title: "Legendary Mekanism Loot Box"
-					type: "command"
-				}
-			]
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
+				icon: "kubejs:legendary_lootbox"
+				id: "2A335028425C54BC"
+				player_command: false
+				title: "Legendary Mekanism Loot Box"
+				type: "command"
+			}]
 			subtitle: "I've Giv'n Her All We've Got, Captain"
 			tasks: [
 				{
@@ -250,8 +217,8 @@
 				}
 			]
 			title: "Supercritical Phase Shifter"
-			x: 7.0d
-			y: 2.0d
+			x: 6.5d
+			y: 2.5d
 		}
 		{
 			dependencies: ["094FAB57D8E3D2F6"]
@@ -276,8 +243,8 @@
 				item: "mekanism:antiprotonic_nucleosynthesizer"
 				type: "item"
 			}]
-			x: 6.0d
-			y: 2.0d
+			x: 6.5d
+			y: 3.5d
 		}
 		{
 			dependencies: ["01E97C3D888A1677"]
@@ -396,7 +363,7 @@
 				type: "item"
 			}]
 			x: -4.0d
-			y: -0.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["2F22D2DB89CB9225"]
@@ -501,57 +468,8 @@
 				title: "Chemical Injection Chamber"
 				type: "item"
 			}]
-			x: 5.5d
-			y: 0.5d
-		}
-		{
-			dependencies: ["094FAB57D8E3D2F6"]
-			description: ["Unsurprisingly, smashing things together to make new things is also an age-old tradition. The Combiner may be used to simplify obtaining a number of decorative blocks."]
-			hide_dependency_lines: true
-			id: "2CEFDF64D65673F0"
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
-				icon: "kubejs:epic_lootbox"
-				id: "2698CDF2EA240362"
-				player_command: false
-				title: "Epic Mekanism Loot Box"
-				type: "command"
-			}]
-			tasks: [{
-				id: "44A2F1D3CBB1CA5F"
-				item: {
-					Count: 1b
-					id: "itemfilters:or"
-					tag: {
-						items: [
-							{
-								Count: 1b
-								id: "mekanism:combiner"
-							}
-							{
-								Count: 1b
-								id: "mekanism:basic_combining_factory"
-							}
-							{
-								Count: 1b
-								id: "mekanism:advanced_combining_factory"
-							}
-							{
-								Count: 1b
-								id: "mekanism:elite_combining_factory"
-							}
-							{
-								Count: 1b
-								id: "mekanism:ultimate_combining_factory"
-							}
-						]
-					}
-				}
-				title: "Combiner"
-				type: "item"
-			}]
-			x: 7.5d
-			y: 0.5d
+			x: 6.0d
+			y: 1.0d
 		}
 		{
 			dependencies: ["01E97C3D888A1677"]
@@ -656,8 +574,8 @@
 					type: "item"
 				}
 			]
-			x: -4.0d
-			y: 0.5d
+			x: -3.5d
+			y: 1.0d
 		}
 		{
 			dependencies: ["06ABB5AAF6BEDC06"]
@@ -763,7 +681,7 @@
 				type: "item"
 			}]
 			x: -2.0d
-			y: -0.5d
+			y: 0.0d
 		}
 		{
 			dependencies: ["2F22D2DB89CB9225"]
@@ -810,8 +728,8 @@
 				item: "mekanism:meka_tool"
 				type: "item"
 			}]
-			x: -2.0d
-			y: 0.5d
+			x: -2.5d
+			y: 1.0d
 		}
 		{
 			dependencies: ["2CCCDD05AED3153F"]

--- a/config/ftbquests/quests/chapters/natures_aura_expert.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura_expert.snbt
@@ -120,10 +120,13 @@
 			]
 			subtitle: "Tire-toi une bûche"
 			tasks: [{
-				count: 8L
-				id: "148F95A06F17918B"
-				item: "naturesaura:wood_stand"
-				type: "item"
+				icon: "naturesaura:wood_stand"
+				id: "05714B3C0C99E55B"
+				observe_type: 0
+				timer: 0L
+				title: "Wooden Stand"
+				to_observe: "naturesaura:wood_stand"
+				type: "observation"
 			}]
 			title: "Ritual of the Forest"
 			x: -4.5d
@@ -444,8 +447,6 @@
 				"A portable source of Aura that can be be put to good use with a variety of tools. "
 				""
 				"Refer to the Book of Natural Aura's section on Natural Tools for potential uses."
-				""
-				"Note: These may not fill completely when worn. To get a full charge, or to even automate filling them, they may be placed in a Natural Altar to their maximum capacity."
 			]
 			hide_dependency_lines: true
 			id: "4081F393EAB01CBE"
@@ -858,8 +859,6 @@
 				""
 				"● Barrens - Prevent the formation of grass on Netherrack."
 				""
-				"● Bountiful Core - Stone and Netherrack are converted to ore with the appropriate Aura type."
-				""
 				"● Steady Growth - The growth of crops, plants, and flowers will no longer be boosted by Aura."
 				""
 				"● Fertility - Passive Animals will breed when able."
@@ -894,17 +893,6 @@
 						id: "naturesaura:effect_powder"
 						tag: {
 							effect: "naturesaura:nether_grass"
-						}
-					}
-					type: "item"
-				}
-				{
-					id: "146C9A440BC7BC35"
-					item: {
-						Count: 1b
-						id: "naturesaura:effect_powder"
-						tag: {
-							effect: "naturesaura:ore_spawn"
 						}
 					}
 					type: "item"

--- a/config/ftbquests/quests/chapters/occultism_expert.snbt
+++ b/config/ftbquests/quests/chapters/occultism_expert.snbt
@@ -47,11 +47,9 @@
 				""
 				"Eating Demon’s Dream fruit pushes back the veil separating this world and the Otherworld, allowing one to see things for what they truly are. In particular, Otherworld trees tend to present themselves as common Oak in this world but may be harvested for what they are while under the effects of the Demon’s Dream."
 				""
-				"Burning the fruit causes a small rift to open into the Otherworld, creating a flame that exists primarily in that Other Place, simply toss it down and light it. This flame will not burn creatures but may be used to transmute or purify certain materials, such as turning Andesite into Otherstone. "
+				"Burning the fruit causes a small rift to open into the Otherworld, creating a flame that exists primarily in that Other Place, simply toss it down and light it. This flame will not burn creatures but may be used to transmute or purify certain materials. "
 				""
 				"Finally, Spirits from the Otherworld adore the taste of this fruit and feeding it to them will help restore their health. "
-				""
-				"Demon’s Dream Seeds may be obtained from the Farming for Blockheads Market."
 			]
 			hide_dependency_lines: true
 			icon: "occultism:spirit_fire"
@@ -67,14 +65,6 @@
 					type: "item"
 				}
 				{
-					auto: "disabled"
-					count: 4
-					id: "03A4D42614CC0815"
-					item: "occultism:spirit_attuned_gem"
-					title: "Spirit Attuned Gem"
-					type: "item"
-				}
-				{
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "10F35B67ABCD0BE9"
@@ -85,39 +75,18 @@
 			]
 			shape: "hexagon"
 			subtitle: "Burnin' For You"
-			tasks: [
-				{
-					id: "7157DB44750699EA"
-					item: "occultism:spirit_attuned_gem"
-					type: "item"
-				}
-				{
-					id: "7882CB600C782FF9"
-					item: "occultism:otherstone"
-					type: "item"
-				}
-				{
-					id: "0783CF8142D7D9CF"
-					item: "occultism:otherworld_log"
-					type: "item"
-				}
-				{
-					id: "317B6BEEED6726F7"
-					item: "occultism:datura"
-					type: "item"
-				}
-			]
+			tasks: [{
+				id: "317B6BEEED6726F7"
+				item: "occultism:datura"
+				type: "item"
+			}]
 			title: "Getting Started: Ritual Magic"
 			x: 13.0d
 			y: 1.0d
 		}
 		{
 			dependencies: ["6174E9BF29FDE7FD"]
-			description: [
-				"Candles are another item used in most ritual pentacles. They are made from the tallow you get by slaughtering pigs, cows, sheep, and other such animals."
-				""
-				"They work as a light source and are also great for decoration!"
-			]
+			description: ["Candles are another item used in most ritual pentacles. Any type of candle will suffice."]
 			icon: "minecraft:purple_candle"
 			id: "2F1875D08B052109"
 			rewards: [{
@@ -129,44 +98,37 @@
 				type: "command"
 			}]
 			subtitle: "Standard Candle"
-			tasks: [
-				{
-					id: "5FB8A527B476873A"
-					item: {
-						Count: 1b
-						id: "itemfilters:or"
-						tag: {
-							items: [
-								{
-									Count: 1b
-									id: "itemfilters:tag"
-									tag: {
-										value: "minecraft:candles"
-									}
+			tasks: [{
+				id: "5FB8A527B476873A"
+				item: {
+					Count: 1b
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "itemfilters:tag"
+								tag: {
+									value: "minecraft:candles"
 								}
-								{
-									Count: 1b
-									id: "itemfilters:tag"
-									tag: {
-										value: "hexerei:candles"
-									}
+							}
+							{
+								Count: 1b
+								id: "itemfilters:tag"
+								tag: {
+									value: "hexerei:candles"
 								}
-								{
-									Count: 1b
-									id: "occultism:candle_white"
-								}
-							]
-						}
+							}
+							{
+								Count: 1b
+								id: "occultism:candle_white"
+							}
+						]
 					}
-					title: "Any Candle"
-					type: "item"
 				}
-				{
-					id: "4E564596C5A296FF"
-					item: "occultism:tallow"
-					type: "item"
-				}
-			]
+				title: "Any Candle"
+				type: "item"
+			}]
 			title: "Candles"
 			x: 12.0d
 			y: 3.0d
@@ -790,11 +752,6 @@
 					id: "16BD98D82120D9CC"
 					type: "advancement"
 				}
-				{
-					id: "6E0E32192386CFB6"
-					item: "occultism:ritual_dummy/summon_djinni_clear_weather"
-					type: "item"
-				}
 			]
 			title: "Weather Rituals"
 			x: 19.0d
@@ -831,14 +788,12 @@
 					advancement: "occultism:occultism/summon_djinni_night_time"
 					criterion: ""
 					id: "557D200FCE67921B"
-					title: "From Dusk..."
 					type: "advancement"
 				}
 				{
 					advancement: "occultism:occultism/summon_djinni_day_time"
 					criterion: ""
 					id: "722922FFAACE6EB0"
-					title: "...Till Dawn"
 					type: "advancement"
 				}
 			]
@@ -988,7 +943,7 @@
 			y: 2.5d
 		}
 		{
-			dependencies: ["1CA681DF652BF0D6"]
+			dependencies: ["1A8FB7EB02DAD9C9"]
 			description: [
 				"Some Familiars lend themselves more to combat situations than others. For those that grant simple bonuses, it is sometimes preferred to keep them in a ring where they can safely provide their bonus without the risk of catching a stray arrow. "
 				""
@@ -996,6 +951,7 @@
 				""
 				"The ring is also useful for trading Familiars with other practitioners, as the Familiar will view whoever releases them from the ring as their new companion."
 			]
+			hide_dependency_lines: true
 			id: "117C9E6DFD48A647"
 			rewards: [{
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
@@ -1082,7 +1038,8 @@
 				"● Devil – Grants Fire Resistance."
 				""
 				"Other"
-				"● Blacksmith – Repairs equipment and applies upgrades to other familiars, enhancing them in a multitude of ways. "
+				"● Blacksmith – Repairs equipment and applies upgrades to "
+				"  other familiars, enhancing them in a multitude of ways. "
 				""
 				"Note: Familiars are protected from friendly fire, and as such it is generally safe to fight near them."
 			]
@@ -1149,8 +1106,8 @@
 			}]
 			shape: "hexagon"
 			tasks: [{
-				id: "59F88416F2D1770C"
-				item: "occultism:spirit_attuned_gem"
+				id: "43742C4BF485D1CC"
+				item: "occultism:otherstone"
 				type: "item"
 			}]
 			title: "Tools and Utility"
@@ -1179,8 +1136,8 @@
 			}]
 			shape: "hexagon"
 			tasks: [{
-				id: "742E2F6B097E7DA8"
-				item: "occultism:spirit_attuned_gem"
+				id: "47C7E7EB53BB26F2"
+				item: "occultism:otherstone"
 				type: "item"
 			}]
 			title: "Storage and Logistics"

--- a/config/ftbquests/quests/chapters/pneumaticcraft_repressurized_expert.snbt
+++ b/config/ftbquests/quests/chapters/pneumaticcraft_repressurized_expert.snbt
@@ -723,7 +723,7 @@
 		{
 			dependencies: ["33C871735DD99224"]
 			description: [
-				"Module Expansion Cards are used to add extra functionality to various Tube Modules. Simply Right-Click it on any Tube Module to add new features"
+				"Module Expansion Crystals are used to add extra functionality to various Tube Modules. Simply Right-Click it on any Tube Module to add new features"
 				""
 				"● Regulator Tube Module: Precise control of regulated pressure."
 				""

--- a/config/ftbquests/quests/chapters/powah_expert.snbt
+++ b/config/ftbquests/quests/chapters/powah_expert.snbt
@@ -118,7 +118,7 @@
 		{
 			dependencies: ["50999062F73B4226"]
 			description: [
-				"Carrying around a battery is an excellent way to keep powered equipment charged on the go, but what if we could regain that inventory slot? The Player Transmitter allows precisely that by remotely charging any items in the owner’s inventory. "
+				"The Player Transmitter is a powerful conduit for funneling magical energies into equipment in the owner’s inventory. "
 				""
 				"To set the owner, craft a Binding Card and Right-Click the card in the air. Doing so will bind the card to that player. The card may then be inserted into the Player Transmitter to configure it."
 			]

--- a/kubejs/client_scripts/base/jei_descriptions.js
+++ b/kubejs/client_scripts/base/jei_descriptions.js
@@ -382,6 +382,12 @@ JEIEvents.information((event) => {
                 ` `,
                 `May also be configured at a Scribe's Table`
             ]
+        },
+        {
+            items: ['mekanism:cardboard_box'],
+            text: [
+                `The functionality of the Cardboard Box has been limited to simple Chests, Barrels, Crates, and other inventories that cannot otherwise be moved easily.`
+            ]
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -32,6 +32,7 @@ ServerEvents.recipes((event) => {
         { input: /rftoolsbase:dimensionalshard_/ },
 
         { id: 'ars_elemental:blaze_crush' },
+        { id: 'ars_elemental:bone_crush' },
 
         { id: /ars_nouveau:.*_dye/ },
 

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -43,6 +43,7 @@ ServerEvents.recipes((event) => {
         { id: 'create:compat/byg/crushing/lignite_ore' },
         { id: 'create:crushing/blaze_rod' },
         { id: 'create:milling/sandstone' },
+        { id: 'create:milling/bone' },
 
         { id: /createaddition:mixing\/biomass/ },
         { id: /createaddition:crafting\/.*spool/ },
@@ -83,6 +84,7 @@ ServerEvents.recipes((event) => {
         { id: 'immersiveengineering:crusher/slag' },
         { id: 'immersiveengineering:crusher/blaze_powder' },
         { id: 'immersiveengineering:crusher/sandstone' },
+        { id: 'immersiveengineering:crusher/bone_meal' },
         { id: 'immersiveengineering:crusher/red_sandstone' },
 
         { id: /mekanism:enriching\/dye/ },

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/book_upgrade.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/book_upgrade.js
@@ -7,7 +7,11 @@ ServerEvents.recipes((event) => {
     const recipes = [
         {
             result: { item: 'ars_nouveau:apprentice_spell_book' },
-            ingredients: [{ item: 'ars_nouveau:novice_spell_book' }, { tag: 'forge:gems/spirit_attuned' }],
+            ingredients: [
+                { item: 'ars_nouveau:novice_spell_book' },
+                { item: 'naturesaura:calling_spirit' },
+                { tag: 'forge:gems/spirit_attuned' }
+            ],
             id: 'ars_nouveau:apprentice_spell_book_upgrade'
         },
         {

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/book_upgrade.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/book_upgrade.js
@@ -7,7 +7,7 @@ ServerEvents.recipes((event) => {
     const recipes = [
         {
             result: { item: 'ars_nouveau:apprentice_spell_book' },
-            ingredients: [{ item: 'ars_nouveau:novice_spell_book' }, { item: 'naturesaura:calling_spirit' }],
+            ingredients: [{ item: 'ars_nouveau:novice_spell_book' }, { tag: 'forge:gems/spirit_attuned' }],
             id: 'ars_nouveau:apprentice_spell_book_upgrade'
         },
         {

--- a/kubejs/server_scripts/expert/recipes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/expert/recipes/naturesaura/tree_ritual.js
@@ -242,7 +242,7 @@ ServerEvents.recipes((event) => {
             output: 'ars_nouveau:scribes_table',
             ingredients: [
                 'supplementaries:antique_ink',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/infused_iron',
                 '#forge:planks/archwood',
                 '#forge:planks/archwood',
                 'naturesaura:gold_leaf',

--- a/kubejs/server_scripts/expert/recipes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/expert/recipes/naturesaura/tree_ritual.js
@@ -242,7 +242,7 @@ ServerEvents.recipes((event) => {
             output: 'ars_nouveau:scribes_table',
             ingredients: [
                 'supplementaries:antique_ink',
-                '#forge:ingots/infused_iron',
+                '#forge:ingots/energized_steel',
                 '#forge:planks/archwood',
                 '#forge:planks/archwood',
                 'naturesaura:gold_leaf',


### PR DESCRIPTION
- Scribe table returned to early progression. This should allow turrets to be used for some simple automation early on.
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/076404c4-5856-46e4-9753-d09de1641016)
- Tier 2 Spellbook changed to maintain gating
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/cc83b922-22de-49ce-afc8-494a8d8d7390)
- Many quests updated to remove references to disabled items.