### PR TITLE
E9E Feedback Changes

### DIFF
--- a/config/ars_nouveau/glyph_aoe.toml
+++ b/config/ars_nouveau/glyph_aoe.toml
@@ -1,17 +1,17 @@
 
 #General settings
 [general]
-	#Is Enabled?
-	enabled = true
 	#Cost
 	#Range: > -2147483648
 	cost = 35
-	#Is Starter Glyph?
-	starter = false
 	#The maximum number of times this glyph may appear in a single spell
 	#Range: > 1
 	per_spell_limit = 2147483647
+	#Is Starter Glyph?
+	starter = false
 	#The tier of the glyph
 	#Range: 1 ~ 99
-	glyph_tier = 2
+	glyph_tier = 1
+	#Is Enabled?
+	enabled = true
 

--- a/config/configswapper/expert/config/ars_nouveau/glyph_aoe.toml
+++ b/config/configswapper/expert/config/ars_nouveau/glyph_aoe.toml
@@ -13,5 +13,5 @@
 	per_spell_limit = 2147483647
 	#The tier of the glyph
 	#Range: 1 ~ 99
-	glyph_tier = 2
+	glyph_tier = 1
 

--- a/config/configswapper/expert/config/ars_nouveau/glyph_blink.toml
+++ b/config/configswapper/expert/config/ars_nouveau/glyph_blink.toml
@@ -13,7 +13,7 @@
 	per_spell_limit = 2147483647
 	#The tier of the glyph
 	#Range: 1 ~ 99
-	glyph_tier = 3
+	glyph_tier = 2
 	#Limits the number of times a given augment may be applied to a given effect
 	#Example entry: "glyph_amplify=5"
 	augment_limits = []

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -2283,6 +2283,38 @@
 			x: -5.5d
 			y: 2.5d
 		}
+		{
+			dependencies: ["4D5B41D89738D3EE"]
+			description: [
+				"Far from home and need a few more potions to top up? The Enchanter’s Eye allows remote casting to a fixed location when bound to a Scry Crystal, or multiple locations with Scryer’s Scrolls. "
+				""
+				"As a simple example of how this may be useful, a Scry Crystal placed facing a Storage Lectern would allow the following spell form to access the Lectern remotely:"
+				""
+				"&5Touch&r > &2Interact&r"
+				""
+				"Adding Sensitive to the spell form would allow remote filling of a flask. Simply hold the flask in the off hand and ensure the Scry Crystal is set facing a Potion Jar:"
+				""
+				"&5Touch&r > &2Interact&r > &6Sensitive&r"
+			]
+			id: "4B6B442259091E1C"
+			rewards: [{
+				count: 2
+				id: "257A6006929C3193"
+				item: "ars_nouveau:scryers_crystal"
+				type: "item"
+			}]
+			tasks: [{
+				id: "12E8A3624A6491C9"
+				item: {
+					Count: 1b
+					id: "ars_nouveau:enchanters_eye"
+					tag: { }
+				}
+				type: "item"
+			}]
+			x: -2.0d
+			y: -1.0d
+		}
 	]
 	title: "Ars Nouveau"
 }

--- a/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
@@ -2312,6 +2312,38 @@
 			x: -5.5d
 			y: 2.5d
 		}
+		{
+			dependencies: ["5A14F3DE74BAE772"]
+			description: [
+				"Far from home and need a few more potions to top up? The Enchanter’s Eye allows remote casting to a fixed location when bound to a Scry Crystal, or multiple locations with Scryer’s Scrolls. "
+				""
+				"As a simple example of how this may be useful, a Scry Crystal placed facing a Storage Lectern would allow the following spell form to access the Lectern remotely:"
+				""
+				"&5Touch&r > &2Interact&r"
+				""
+				"Adding Sensitive to the spell form would allow remote filling of a flask. Simply hold the flask in the off hand and ensure the Scry Crystal is set facing a Potion Jar:"
+				""
+				"&5Touch&r > &2Interact&r > &6Sensitive&r"
+			]
+			id: "62DC38C5A8D7AA3A"
+			rewards: [{
+				count: 2
+				id: "12F3CB6463DA3B43"
+				item: "ars_nouveau:scryers_crystal"
+				type: "item"
+			}]
+			tasks: [{
+				id: "4CA1EF93C063A2EF"
+				item: {
+					Count: 1b
+					id: "ars_nouveau:enchanters_eye"
+					tag: { }
+				}
+				type: "item"
+			}]
+			x: -2.0d
+			y: -1.0d
+		}
 	]
 	title: "Ars Nouveau"
 }

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -2148,6 +2148,45 @@
 			x: -8.0d
 			y: -0.5d
 		}
+		{
+			dependencies: ["345CBD118EAA0C09"]
+			description: [
+				"The practice of divination dates back centuries and all manner of material has been used for a focus, from tea leaves to entrails. "
+				""
+				"While certainly effective, those methods were preferred by some merely for the spectacle; anything can be used to tune one’s mind for the task. "
+			]
+			hide_dependency_lines: true
+			id: "37A128B304BAC0EC"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
+				icon: "kubejs:miners_delight"
+				id: "0278C7667B0EC3FE"
+				player_command: false
+				title: "Miner's Delight"
+				type: "command"
+			}]
+			shape: "hexagon"
+			tasks: [{
+				id: "38BBFF1EA9A911FD"
+				item: {
+					Count: 1b
+					id: "theurgy:divination_rod_t3"
+					tag: {
+						Damage: 0
+						"theurgy:divination.setting.allow_attuning": 1b
+						"theurgy:divination.setting.allowed_blocks_tag": "theurgy:divination_rod_t4_allowed_blocks"
+						"theurgy:divination.setting.disallowed_blocks_tag": "theurgy:divination_rod_t4_disallowed_blocks"
+						"theurgy:divination.setting.duration": 40.0d
+						"theurgy:divination.setting.max_damage": 512.0d
+						"theurgy:divination.setting.range": 96.0d
+						"theurgy:divination.setting.tier": "minecraft:netherite"
+					}
+				}
+				type: "item"
+			}]
+			x: 2.0d
+			y: 2.5d
+		}
 	]
 	title: "Chapter One"
 }

--- a/config/ftbquests/quests/chapters/chapter_two.snbt
+++ b/config/ftbquests/quests/chapters/chapter_two.snbt
@@ -916,7 +916,7 @@
 				}
 			]
 			title: "Tree of Life"
-			x: 6.5d
+			x: 7.5d
 			y: 3.0d
 		}
 		{
@@ -948,7 +948,7 @@
 					type: "item"
 				}
 			]
-			x: 6.5d
+			x: 7.5d
 			y: 4.0d
 		}
 		{
@@ -1121,6 +1121,32 @@
 			}]
 			x: 6.5d
 			y: 1.0d
+		}
+		{
+			dependencies: ["60324503ED7AC4C1"]
+			hide_dependency_lines: true
+			id: "6DB541631BF1FBFC"
+			shape: "hexagon"
+			tasks: [{
+				id: "67E12A5977051DA4"
+				item: {
+					Count: 1b
+					id: "theurgy:divination_rod_t3"
+					tag: {
+						Damage: 0
+						"theurgy:divination.setting.allow_attuning": 1b
+						"theurgy:divination.setting.allowed_blocks_tag": "theurgy:divination_rod_t4_allowed_blocks"
+						"theurgy:divination.setting.disallowed_blocks_tag": "theurgy:divination_rod_t4_disallowed_blocks"
+						"theurgy:divination.setting.duration": 40.0d
+						"theurgy:divination.setting.max_damage": 512.0d
+						"theurgy:divination.setting.range": 96.0d
+						"theurgy:divination.setting.tier": "minecraft:netherite"
+					}
+				}
+				type: "item"
+			}]
+			x: 6.5d
+			y: 2.0d
 		}
 	]
 	title: "Chapter Two"

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -562,5 +562,11 @@
     "ritual.enigmatica.occultism/ritual/wilden_grove_gate.started": "Started Summoning the Grove of the Wilden",
     "ritual.enigmatica.occultism/ritual/wilden_grove_gate.finished": "The Grove of the Wilden gateway has opened",
     "ritual.enigmatica.occultism/ritual/wilden_grove_gate.interrupted": "The Grove of the Wilden gateway has been interrupted",
-    "ritual.enigmatica.occultism/ritual/wilden_grove_gate.conditions": "Not all requirements for this ritual are met."
+    "ritual.enigmatica.occultism/ritual/wilden_grove_gate.conditions": "Not all requirements for this ritual are met.",
+
+    "gateways.wild_hunt_gate": "Wild Hunt Gate",
+    "ritual.enigmatica.occultism/ritual/wild_hunt_gate.started": "Started Summoning the Wild Hunt",
+    "ritual.enigmatica.occultism/ritual/wild_hunt_gate.finished": "The Wild Hunt gateway has opened",
+    "ritual.enigmatica.occultism/ritual/wild_hunt_gate.interrupted": "The Wild Hunt gateway has been interrupted",
+    "ritual.enigmatica.occultism/ritual/wild_hunt_gate.conditions": "Not all requirements for this ritual are met."
 }

--- a/kubejs/client_scripts/constants/jei_hidden_disabled.js
+++ b/kubejs/client_scripts/constants/jei_hidden_disabled.js
@@ -539,6 +539,7 @@ jei.expert.items.disabled = [
     'occultism:lenses',
     'occultism:magic_lamp_empty',
     'occultism:spirit_attuned_pickaxe_head',
+    'occultism:ritual_dummy/summon_wild_hunt',
 
     'pneumaticcraft:air_compressor',
     'pneumaticcraft:electrostatic_compressor',

--- a/kubejs/server_scripts/base/gamerules/default.js
+++ b/kubejs/server_scripts/base/gamerules/default.js
@@ -1,0 +1,11 @@
+ServerEvents.loaded((event) => {
+    let gamerules = [{ rule: 'doFireTick', value: 'false' }];
+
+    gamerules.forEach((gamerule) => {
+        if (!event.server.persistentData[gamerule.rule]) {
+            event.server.runCommandSilent(`/gamerule ${gamerule.rule} ${gamerule.value}`);
+            console.log(`Default Gamerule Applied: ${gamerule.rule} = ${gamerule.value}`);
+            event.server.persistentData[gamerule.rule] = gamerule.value;
+        }
+    });
+});

--- a/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/wild_hunt.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/wild_hunt.js
@@ -81,10 +81,7 @@ ServerEvents.highPriorityData((event) => {
             ],
             helmets: [
                 {
-                    stack: {
-                        item: 'minecraft:wither_skeleton_skull',
-                        nbt: leather_colors.black
-                    },
+                    stack: { item: 'minecraft:wither_skeleton_skull' },
                     weight: 100,
                     drop_chance: 1.0
                 }

--- a/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/wild_hunt.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/wild_hunt.js
@@ -82,11 +82,11 @@ ServerEvents.highPriorityData((event) => {
             helmets: [
                 {
                     stack: {
-                        item: 'minecraft:leather_helmet',
+                        item: 'minecraft:wither_skeleton_skull',
                         nbt: leather_colors.black
                     },
                     weight: 100,
-                    drop_chance: 0.085
+                    drop_chance: 1.0
                 }
             ],
             chestplates: [

--- a/kubejs/server_scripts/base/recipes/gateways/gateways.js
+++ b/kubejs/server_scripts/base/recipes/gateways/gateways.js
@@ -220,7 +220,7 @@ ServerEvents.highPriorityData((event) => {
         {
             size: 'large',
             color: '#a005fa',
-            leash_range: 32,
+            leash_range: 256,
             rewards: [
                 {
                     type: 'stack',

--- a/kubejs/server_scripts/base/recipes/gateways/gateways.js
+++ b/kubejs/server_scripts/base/recipes/gateways/gateways.js
@@ -7,6 +7,7 @@ ServerEvents.highPriorityData((event) => {
             size: 'small',
             color: '#0b9e32',
             leash_range: 256,
+            allow_discarding: true,
             rewards: [
                 {
                     type: 'stack',
@@ -121,6 +122,7 @@ ServerEvents.highPriorityData((event) => {
             size: 'large',
             color: '#b30f04',
             leash_range: 32,
+            allow_discarding: true,
             rewards: [
                 {
                     type: 'stack',
@@ -221,6 +223,7 @@ ServerEvents.highPriorityData((event) => {
             size: 'large',
             color: '#a005fa',
             leash_range: 256,
+            allow_discarding: true,
             rewards: [
                 {
                     type: 'stack',
@@ -327,6 +330,116 @@ ServerEvents.highPriorityData((event) => {
                 }
             ],
             id: 'wilden_grove_gate'
+        },
+        {
+            size: 'large',
+            color: '#554a57',
+            leash_range: 32,
+            rewards: [
+                {
+                    type: 'stack',
+                    stack: Item.of('kubejs:aura_leaf', '{aura_amount:20000.0d,aura_max:1500000.0d}')
+                },
+                {
+                    type: 'apotheosis:affix',
+                    rarity: 'rare'
+                },
+                {
+                    type: 'loot_table',
+                    loot_table: 'enigmatica:apotheosis_gem_cache',
+                    rolls: 5,
+                    desc: 'Apotheosis Gems'
+                }
+            ],
+            completion_xp: 5000,
+            spawn_range: 3,
+            waves: [
+                {
+                    entities: [
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' }
+                    ],
+                    rewards: [
+                        {
+                            type: 'stack',
+                            stack: Item.of('kubejs:aura_leaf', '{aura_amount:20000.0d,aura_max:1500000.0d}')
+                        }
+                    ],
+                    max_wave_time: 750,
+                    setup_time: 50
+                },
+                {
+                    entities: [
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'twilightforest:wraith' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' }
+                    ],
+                    rewards: [
+                        {
+                            type: 'stack',
+                            stack: Item.of('kubejs:aura_leaf', '{aura_amount:20000.0d,aura_max:1500000.0d}')
+                        }
+                    ],
+                    max_wave_time: 1500,
+                    setup_time: 50
+                },
+                {
+                    entities: [
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_wither_skeleton' },
+                        { entity: 'occultism:wild_hunt_wither_skeleton' },
+                        { entity: 'occultism:wild_hunt_wither_skeleton' }
+                    ],
+                    rewards: [
+                        {
+                            type: 'stack',
+                            stack: Item.of('kubejs:aura_leaf', '{aura_amount:20000.0d,aura_max:1500000.0d}')
+                        }
+                    ],
+                    max_wave_time: 2400,
+                    setup_time: 50
+                },
+                {
+                    entities: [
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_skeleton' },
+                        { entity: 'occultism:wild_hunt_wither_skeleton' },
+                        { entity: 'occultism:wild_hunt_wither_skeleton' },
+                        { entity: 'occultism:wild_hunt_wither_skeleton' }
+                    ],
+                    rewards: [
+                        {
+                            type: 'stack',
+                            stack: Item.of('kubejs:aura_leaf', '{aura_amount:20000.0d,aura_max:1500000.0d}')
+                        }
+                    ],
+                    max_wave_time: 2400,
+                    setup_time: 50
+                }
+            ],
+            id: 'wild_hunt_gate'
         }
     ];
 

--- a/kubejs/server_scripts/base/tags/blocks/mekanism/cardboard_blacklist.js
+++ b/kubejs/server_scripts/base/tags/blocks/mekanism/cardboard_blacklist.js
@@ -2,10 +2,10 @@ ServerEvents.tags('block', (event) => {
     event
         .get('mekanism:cardboard_blacklist')
         .add(/.*/)
-        .remove([/chest$/, /drawer$/, /cooler$/, /crate$/, /cabinet$/, /barrel$/, /basket$/])
+        .remove([/chest$/, /drawer$/, /cooler$/, /crate$/, /cabinet$/, /barrel$/, /basket$/, /repository$/])
         .add([/sophisticated.*:/, /mekanism:/, /functionalstorage:/]);
     event
         .get('mekanism:cardboard_whitelist')
-        .add([/chest$/, /drawer$/, /cooler$/, /crate$/, /cabinet$/, /barrel$/, /basket$/])
+        .add([/chest$/, /drawer$/, /cooler$/, /crate$/, /cabinet$/, /barrel$/, /basket$/, /repository$/])
         .remove([/sophisticated.*:/, /mekanism:/, /functionalstorage:/]);
 });

--- a/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/death_tome.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/death_tome.js
@@ -49,6 +49,7 @@ ServerEvents.entityLootTables((event) => {
             pool.addItem('ars_nouveau:glyph_toss', 2);
             pool.addItem('ars_nouveau:glyph_underfoot', 2);
             pool.addItem('ars_nouveau:glyph_crush', 2);
+            pool.addItem('ars_nouveau:glyph_aoe', 2);
 
             pool.addItem('toomanyglyphs:glyph_filter_animal', 1);
             pool.addItem('toomanyglyphs:glyph_filter_block', 1);

--- a/kubejs/server_scripts/expert/player_events/starting_items.js
+++ b/kubejs/server_scripts/expert/player_events/starting_items.js
@@ -19,7 +19,7 @@ PlayerEvents.loggedIn((event) => {
             '64x minecraft:arrow',
             '64x minecraft:arrow',
             '64x minecraft:arrow',
-            'twilightforest:maze_map',
+            'twilightforest:magic_map',
             Item.of(
                 'sophisticatedbackpacks:backpack',
                 '{borderColor:6258977,clothColor:6846789,inventorySlots:27,upgradeSlots:1}'

--- a/kubejs/server_scripts/expert/recipes/create/compacting.js
+++ b/kubejs/server_scripts/expert/recipes/create/compacting.js
@@ -29,9 +29,7 @@ ServerEvents.recipes((event) => {
                 [{ tag: 'forge:foods/meat/raw' }, { item: 'minecraft:rotten_flesh' }],
                 [{ tag: 'forge:foods/meat/raw' }, { item: 'minecraft:rotten_flesh' }],
                 [{ tag: 'forge:foods/meat/raw' }, { item: 'minecraft:rotten_flesh' }],
-                [{ tag: 'forge:foods/meat/raw' }, { item: 'minecraft:rotten_flesh' }],
-                [{ item: 'minecraft:spider_eye' }],
-                [{ item: 'minecraft:spider_eye' }]
+                [{ tag: 'forge:foods/meat/raw' }, { item: 'minecraft:rotten_flesh' }]
             ],
             results: [
                 { fluid: 'hexerei:blood_fluid', amount: 250 },

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -516,6 +516,8 @@ ServerEvents.recipes((event) => {
         { id: 'thermal:machines/pulverizer/pulverizer_diamond' },
         { id: 'thermal:machines/crucible/crucible_ender_pearl' },
 
+        { id: /theurgy:.*divination_rod/ },
+
         { id: 'toomanyglyphs:glyph_chaining' },
 
         { id: 'twilightforest:equipment/fiery_ingot_crafting' },

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/squeezer.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/squeezer.js
@@ -10,6 +10,13 @@ ServerEvents.recipes((event) => {
             input: [{ item: 'ars_nouveau:mendosteen_pod' }],
             energy: 6400,
             id: `${id_prefix}mendosteen_mash`
+        },
+        {
+            fluid: { amount: 250, fluid: 'hexerei:blood_fluid' },
+            input: { base_ingredient: [{ tag: 'forge:foods/meat/raw' }, { item: 'minecraft:rotten_flesh' }], count: 4 },
+            result: { item: 'kubejs:mystery_mash', count: 2 },
+            energy: 1280,
+            id: `${id_prefix}blood_fluid`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/occultism/ritual.js
+++ b/kubejs/server_scripts/expert/recipes/occultism/ritual.js
@@ -1228,23 +1228,6 @@ ServerEvents.recipes((event) => {
             id: `occultism:ritual/possess_ghast`
         },
         {
-            output: Item.of('minecraft:wither_skeleton_skull', {
-                display: {
-                    Name: '{"translate":"item.occultism.ritual_dummy.summon_wild_hunt"}',
-                    Lore: ['{"translate":"item.occultism.ritual_dummy.summon_wild_hunt.tooltip"}']
-                }
-            }),
-            activation_item: 'minecraft:skeleton_skull',
-            inputs: ['#forge:essences/anima', '#forge:dusts/lead', '#forge:dusts/lead', '#forge:dusts/lead'],
-            entity_to_summon: 'occultism:wild_hunt_wither_skeleton',
-            entity_to_sacrifice: { tag: 'enigmatica:deer', display_name: 'ritual.occultism.sacrifice.deer' },
-            ritual_dummy: 'occultism:ritual_dummy/summon_wild_hunt',
-            ritual_type: 'occultism:summon',
-            pentacle_id: 'occultism:summon_lesser_evil',
-            duration: 10,
-            id: `occultism:ritual/summon_wild_hunt`
-        },
-        {
             output: Item.of('occultism:afrit_essence', {
                 display: {
                     Name: '{"translate":"item.occultism.ritual_dummy.summon_wild_afrit"}',
@@ -1516,6 +1499,22 @@ ServerEvents.recipes((event) => {
             pentacle_id: 'occultism:summon_foliot',
             duration: 20,
             id: `${id_prefix}ritual_of_enduring_flight`
+        },
+        {
+            output: Item.of('gateways:gate_pearl', `{gateway:"gateways:wild_hunt_gate", radius:5}`),
+            activation_item: 'minecraft:skeleton_skull',
+            inputs: ['#forge:essences/anima', '#forge:dusts/lead', '#forge:dusts/lead', '#forge:dusts/lead'],
+            entity_to_sacrifice: { tag: 'enigmatica:deer', display_name: 'ritual.occultism.sacrifice.deer' },
+            ritual_dummy: Item.of('minecraft:wither_skeleton_skull', {
+                display: {
+                    Name: '{"translate":"item.occultism.ritual_dummy.summon_wild_hunt"}',
+                    Lore: ['{"translate":"item.occultism.ritual_dummy.summon_wild_hunt.tooltip"}']
+                }
+            }),
+            ritual_type: 'occultism:craft',
+            pentacle_id: 'occultism:summon_lesser_evil',
+            duration: 10,
+            id: `occultism:ritual/summon_wild_hunt`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/theurgy/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/theurgy/shaped.js
@@ -1,0 +1,32 @@
+ServerEvents.recipes((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/theurgy/shaped/';
+
+    const recipes = [
+        {
+            output: Item.of('theurgy:divination_rod_t3', {
+                'theurgy:divination.setting.tier': 'minecraft:netherite',
+                'theurgy:divination.setting.allowed_blocks_tag': 'theurgy:divination_rod_t4_allowed_blocks',
+                'theurgy:divination.setting.disallowed_blocks_tag': 'theurgy:divination_rod_t4_disallowed_blocks',
+                'theurgy:divination.setting.range': 96,
+                'theurgy:divination.setting.duration': 40,
+                'theurgy:divination.setting.max_damage': 512
+            }),
+            pattern: [' AB', ' CA', 'DE '],
+            key: {
+                A: '#forge:nuggets/electrum',
+                B: '#forge:gems/source',
+                C: '#forge:rods/aluminum',
+                D: '#forge:rods/wooden',
+                E: '#forge:leather'
+            },
+            id: `${id_prefix}divination_rod_t3`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});


### PR DESCRIPTION
- Magic Map Starting Gear fixed
- AoE now tier 1, added to Death Tome loot
- Blood can now be made in a squeezer too. Eyes no longer required.
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/8d20bf19-c9da-4187-953b-990509d8a203)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/e076ff4a-11ef-46c5-ae24-97d9d63ef852)
- Divination Rods reduced to 1 tier, durability increased.
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/ad3d43ca-425e-4a97-ae27-28545c96ae71)
- Wilden Grove gate leash range extended to 256 blocks to avoid them leaping out of the area
- Wilden Grove, Wither Council, and Spawner Rifts now allow mobs to be removed without killing them
- Blink Glyph moved to Tier 2
- Wild Hunt moved to a gateway, more mobs spawned with greater access to skulls
- Default doFireTick to false for new worlds

