### PR TITLE
E9E Feedback Changes

### DIFF
--- a/config/ars_nouveau/glyph_grow.toml
+++ b/config/ars_nouveau/glyph_grow.toml
@@ -1,20 +1,20 @@
 
 #General settings
 [general]
-	#Is Enabled?
-	enabled = true
-	#Cost
-	#Range: > -2147483648
-	cost = 70
-	#Is Starter Glyph?
-	starter = false
-	#The maximum number of times this glyph may appear in a single spell
-	#Range: > 1
-	per_spell_limit = 2147483647
-	#The tier of the glyph
-	#Range: 1 ~ 99
-	glyph_tier = 2
 	#Limits the number of times a given augment may be applied to a given effect
 	#Example entry: "glyph_amplify=5"
 	augment_limits = []
+	#Cost
+	#Range: > -2147483648
+	cost = 10
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#Is Starter Glyph?
+	starter = false
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 1
+	#Is Enabled?
+	enabled = true
 

--- a/kubejs/client_scripts/lang_modifications.js
+++ b/kubejs/client_scripts/lang_modifications.js
@@ -33,49 +33,49 @@ const entries = {
             key: 'item.emendatusenigmatica.brass_ingot',
             value: {
                 normal: 'Brass Ingot',
-                expert: 'Aetheric Brass Ingot'
+                expert: 'Orichalcum Ingot'
             }
         },
         {
             key: 'item.emendatusenigmatica.brass_nugget',
             value: {
                 normal: 'Brass Nugget',
-                expert: 'Aetheric Brass Nugget'
+                expert: 'Orichalcum Nugget'
             }
         },
         {
             key: 'item.emendatusenigmatica.brass_dust',
             value: {
                 normal: 'Brass Dust',
-                expert: 'Aetheric Brass Dust'
+                expert: 'Orichalcum Dust'
             }
         },
         {
             key: 'item.emendatusenigmatica.brass_plate',
             value: {
                 normal: 'Brass Plate',
-                expert: 'Aetheric Brass Plate'
+                expert: 'Orichalcum Plate'
             }
         },
         {
             key: 'item.emendatusenigmatica.brass_gear',
             value: {
                 normal: 'Brass Gear',
-                expert: 'Aetheric Brass Gear'
+                expert: 'Orichalcum Gear'
             }
         },
         {
             key: 'item.emendatusenigmatica.brass_rod',
             value: {
                 normal: 'Brass Rod',
-                expert: 'Aetheric Brass Rod'
+                expert: 'Orichalcum Rod'
             }
         },
         {
             key: 'block.emendatusenigmatica.brass_block',
             value: {
                 normal: 'Block of Brass',
-                expert: 'Block of Aetheric Brass'
+                expert: 'Block of Orichalcum'
             }
         }
     ],
@@ -1010,14 +1010,14 @@ const entries = {
             key: 'block.powah.energized_steel_block',
             value: {
                 normal: 'Block Of Energized Steel',
-                expert: 'Block of Orichalcum'
+                expert: 'Block of Aetheric Brass'
             }
         },
         {
             key: 'item.powah.steel_energized',
             value: {
                 normal: 'Energized Steel',
-                expert: 'Orichalcum Ingot'
+                expert: 'Aetheric Brass Ingot'
             }
         },
         {

--- a/kubejs/server_scripts/base/recipes/ars_nouveau/crushing.js
+++ b/kubejs/server_scripts/base/recipes/ars_nouveau/crushing.js
@@ -52,6 +52,16 @@ ServerEvents.recipes((event) => {
             ],
             input: 'minecraft:moss_block',
             id: `${id_prefix}moss_paste`
+        },
+        {
+            output: [{ item: 'minecraft:cobblestone', count: 1, chance: 1.0 }],
+            input: 'minecraft:stone',
+            id: `ars_nouveau:crush_stone`
+        },
+        {
+            output: [{ item: 'ae2:sky_dust', count: 1, chance: 1.0 }],
+            input: 'ae2:sky_stone_block',
+            id: `${id_prefix}sky_dust`
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/create/milling.js
+++ b/kubejs/server_scripts/base/recipes/create/milling.js
@@ -1,7 +1,14 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/create/milling/';
 
-    let recipes = [];
+    let recipes = [
+        {
+            outputs: [{ item: 'minecraft:cobblestone', count: 1 }],
+            inputs: ['minecraft:stone'],
+            processingTime: 60,
+            id: `${id_prefix}cobblestone`
+        }
+    ];
 
     sandstone_colors.forEach((color) => {
         let output = '';

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -52,6 +52,7 @@ ServerEvents.recipes((event) => {
         { id: 'create:crushing/blaze_rod' },
         { id: 'create:milling/sandstone' },
         { id: 'create:milling/bone' },
+        { id: 'create:milling/andesite' },
 
         { id: /createaddition:mixing\/biomass/ },
         { id: /createaddition:crafting\/.*spool/ },

--- a/kubejs/server_scripts/expert/recipes/ae2/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ae2/shaped.js
@@ -112,7 +112,7 @@ ServerEvents.recipes((event) => {
             pattern: ['ABA', 'BCB', 'ABA'],
             key: {
                 A: '#forge:ingots/compressed_iron',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: 'ae2:quartz_glass'
             },
             id: `ae2:network/blocks/pattern_providers_interface`

--- a/kubejs/server_scripts/expert/recipes/ae2/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ae2/shaped.js
@@ -112,7 +112,7 @@ ServerEvents.recipes((event) => {
             pattern: ['ABA', 'BCB', 'ABA'],
             key: {
                 A: '#forge:ingots/compressed_iron',
-                B: '#forge:ingots/brass',
+                B: '#forge:plates/brass',
                 C: 'ae2:quartz_glass'
             },
             id: `ae2:network/blocks/pattern_providers_interface`

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
@@ -14,7 +14,7 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'occultism:storage_controller_base',
-            inputs: ['#forge:ingots/energized_steel', '#forge:ingots/energized_steel', '#forge:ingots/energized_steel'],
+            inputs: ['#forge:ingots/brass', '#forge:ingots/brass', '#forge:ingots/brass'],
             reagents: ['occultism:otherstone_pedestal'],
             sourceCost: 2000,
             id: `${id_prefix}storage_controller_base`
@@ -66,7 +66,7 @@ ServerEvents.recipes((event) => {
         {
             output: 'create:brass_hand',
             inputs: ['#forge:essences/manipulation', '#forge:leather', '#forge:leather', '#forge:leather'],
-            reagents: ['#forge:ingots/energized_steel'],
+            reagents: ['#forge:ingots/brass'],
             sourceCost: 1000,
             id: `${id_prefix}brass_hand`
         },
@@ -859,13 +859,13 @@ ServerEvents.recipes((event) => {
             output: 'superiorshields:enchanter_shield',
             inputs: [
                 'ars_elemental:glyph_bubble_shield',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 '#forge:gems/source',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'ars_nouveau:glyph_self',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 '#forge:gems/source',
-                '#forge:ingots/energized_steel'
+                '#forge:ingots/brass'
             ],
             reagents: [
                 'superiorshields:knightmetal_shield',
@@ -883,11 +883,11 @@ ServerEvents.recipes((event) => {
             output: 'apotheosis:sigil_of_socketing',
             inputs: [
                 'apotheosis:gem_dust',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'apotheosis:gem_dust',
                 'apotheosis:gem_dust',
                 'apotheosis:gem_dust',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'apotheosis:gem_dust',
                 'apotheosis:gem_dust'
             ],

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
@@ -58,21 +58,22 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'ars_nouveau:arcane_core',
-            pattern: ['AAA', 'BCB', 'AAA'],
+            pattern: ['ABA', 'CDC', 'ABA'],
             key: {
-                A: 'ars_nouveau:sourcestone',
-                B: '#forge:ingots/brass',
-                C: '#forge:gems/source'
+                A: '#forge:plates/brass',
+                B: 'ars_nouveau:sourcestone',
+                C: '#forge:planks/archwood',
+                D: 'ae2:fluix_block'
             },
             id: `ars_nouveau:arcane_core`
         },
         {
             output: 'ars_nouveau:enchanting_apparatus',
-            pattern: ['BAB', ' C ', 'BAB'],
+            pattern: ['BAB', 'C C', 'BAB'],
             key: {
                 A: 'ars_nouveau:sourcestone',
-                B: '#forge:ingots/brass',
-                C: '#forge:gems/fluix'
+                B: '#forge:rods/brass',
+                C: '#forge:nuggets/brass'
             },
             id: `ars_nouveau:enchanting_apparatus`
         },

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
@@ -61,7 +61,7 @@ ServerEvents.recipes((event) => {
             pattern: ['AAA', 'BCB', 'AAA'],
             key: {
                 A: 'ars_nouveau:sourcestone',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:gems/source'
             },
             id: `ars_nouveau:arcane_core`
@@ -71,7 +71,7 @@ ServerEvents.recipes((event) => {
             pattern: ['BAB', ' C ', 'BAB'],
             key: {
                 A: 'ars_nouveau:sourcestone',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:gems/fluix'
             },
             id: `ars_nouveau:enchanting_apparatus`

--- a/kubejs/server_scripts/expert/recipes/create/item_application.js
+++ b/kubejs/server_scripts/expert/recipes/create/item_application.js
@@ -22,7 +22,7 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}andesite_casing_from_treated_wood`
         },
         {
-            ingredients: [{ tag: 'forge:treated_wood' }, { tag: 'forge:ingots/energized_steel' }],
+            ingredients: [{ tag: 'forge:treated_wood' }, { tag: 'forge:ingots/brass' }],
             results: [{ item: 'create:brass_casing' }],
             id: `${id_prefix}brass_casing_from_treated_wood`
         },

--- a/kubejs/server_scripts/expert/recipes/create/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/create/shaped.js
@@ -262,8 +262,8 @@ ServerEvents.recipes((event) => {
             output: 'create:peculiar_bell',
             pattern: ['A', 'B'],
             key: {
-                A: '#forge:storage_blocks/energized_steel',
-                B: '#forge:ingots/energized_steel'
+                A: '#forge:storage_blocks/brass',
+                B: '#forge:ingots/brass'
             },
             id: `create:crafting/curiosities/peculiar_bell`
         },
@@ -386,7 +386,7 @@ ServerEvents.recipes((event) => {
             output: 'create:smart_fluid_pipe',
             pattern: ['A', 'B', 'C'],
             key: {
-                A: '#forge:ingots/energized_steel',
+                A: '#forge:ingots/brass',
                 B: 'create:fluid_pipe',
                 C: 'pneumaticcraft:logistics_core'
             },
@@ -396,7 +396,7 @@ ServerEvents.recipes((event) => {
             output: 'create:smart_chute',
             pattern: ['A', 'B', 'C'],
             key: {
-                A: '#forge:ingots/energized_steel',
+                A: '#forge:ingots/brass',
                 B: 'create:chute',
                 C: 'pneumaticcraft:logistics_core'
             },

--- a/kubejs/server_scripts/expert/recipes/create/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/create/shaped.js
@@ -263,7 +263,7 @@ ServerEvents.recipes((event) => {
             pattern: ['A', 'B'],
             key: {
                 A: '#forge:storage_blocks/brass',
-                B: '#forge:ingots/brass'
+                B: '#forge:rods/brass'
             },
             id: `create:crafting/curiosities/peculiar_bell`
         },
@@ -386,7 +386,7 @@ ServerEvents.recipes((event) => {
             output: 'create:smart_fluid_pipe',
             pattern: ['A', 'B', 'C'],
             key: {
-                A: '#forge:ingots/brass',
+                A: '#forge:plates/brass',
                 B: 'create:fluid_pipe',
                 C: 'pneumaticcraft:logistics_core'
             },
@@ -396,7 +396,7 @@ ServerEvents.recipes((event) => {
             output: 'create:smart_chute',
             pattern: ['A', 'B', 'C'],
             key: {
-                A: '#forge:ingots/brass',
+                A: '#forge:plates/brass',
                 B: 'create:chute',
                 C: 'pneumaticcraft:logistics_core'
             },

--- a/kubejs/server_scripts/expert/recipes/functionalstorage/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/functionalstorage/shaped.js
@@ -33,7 +33,7 @@ ServerEvents.recipes((event) => {
                 A: '#forge:stone',
                 B: '#functionalstorage:drawer',
                 C: 'minecraft:comparator',
-                D: '#forge:ingots/brass'
+                D: '#forge:gears/brass'
             },
             id: 'functionalstorage:armory_cabinet'
         },

--- a/kubejs/server_scripts/expert/recipes/functionalstorage/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/functionalstorage/shaped.js
@@ -33,7 +33,7 @@ ServerEvents.recipes((event) => {
                 A: '#forge:stone',
                 B: '#functionalstorage:drawer',
                 C: 'minecraft:comparator',
-                D: '#forge:ingots/energized_steel'
+                D: '#forge:ingots/brass'
             },
             id: 'functionalstorage:armory_cabinet'
         },

--- a/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
+++ b/kubejs/server_scripts/expert/recipes/hexerei/mixingcauldron.js
@@ -739,13 +739,13 @@ ServerEvents.recipes((event) => {
             output: '4x kubejs:iridescent_arcanite_crystal',
             inputs: [
                 'kubejs:bright_arcanite_crystal',
-                '#forge:dusts/brass',
-                '#forge:dusts/brass',
-                '#forge:dusts/brass',
+                '#forge:ingots/energized_steel',
+                '#forge:ingots/energized_steel',
+                '#forge:ingots/energized_steel',
                 '#forge:gems/nitro',
-                '#forge:dusts/brass',
-                '#forge:dusts/brass',
-                '#forge:dusts/brass'
+                '#forge:ingots/energized_steel',
+                '#forge:ingots/energized_steel',
+                '#forge:ingots/energized_steel'
             ],
             liquid: { fluid: 'hexerei:potion', nbt: { Bottle: 'REGULAR', Potion: 'ars_elemental:shock_potion' } },
             liquidOutput: {

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/bottling_machine.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/bottling_machine.js
@@ -27,7 +27,7 @@ ServerEvents.recipes((event) => {
             results: [{ item: 'create:brass_casing', count: 4 }],
             inputs: [
                 { base_ingredient: { item: 'thermal:sawdust_block' }, count: 4 },
-                { base_ingredient: { tag: 'forge:ingots/energized_steel' }, count: 1 }
+                { base_ingredient: { tag: 'forge:ingots/brass' }, count: 1 }
             ],
             fluid: { amount: 100, tag: 'forge:phenolic_resin' },
             id: `${id_prefix}brass_casing`

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/shaped.js
@@ -502,6 +502,16 @@ ServerEvents.recipes((event) => {
                 B: '#forge:fabrics/tough'
             },
             id: `immersiveengineering:crafting/strip_curtain`
+        },
+        {
+            output: '3x immersiveengineering:blastbrick_reinforced',
+            pattern: ['AAA', 'BBB', 'CCC'],
+            key: {
+                A: 'immersiveengineering:blastbrick',
+                B: '#forge:plates/obsidian',
+                C: '#forge:plates/brass'
+            },
+            id: 'immersiveengineering:crafting/blastbrick_reinforced'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/shapeless.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/shapeless.js
@@ -4,21 +4,7 @@ ServerEvents.recipes((event) => {
     }
     const id_prefix = 'enigmatica:expert/immersiveengineering/shapeless/';
 
-    const recipes = [
-        {
-            output: '3x immersiveengineering:blastbrick_reinforced',
-            inputs: [
-                'immersiveengineering:blastbrick',
-                'immersiveengineering:blastbrick',
-                'immersiveengineering:blastbrick',
-                '#forge:plates/obsidian',
-                '#forge:plates/obsidian',
-                '#forge:plates/obsidian',
-                '#forge:ingots/brass'
-            ],
-            id: 'immersiveengineering:crafting/blastbrick_reinforced'
-        }
-    ];
+    const recipes = [];
 
     colors.forEach((color) => {
         recipes.push({

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/shapeless.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/shapeless.js
@@ -14,7 +14,7 @@ ServerEvents.recipes((event) => {
                 '#forge:plates/obsidian',
                 '#forge:plates/obsidian',
                 '#forge:plates/obsidian',
-                '#forge:ingots/energized_steel'
+                '#forge:ingots/brass'
             ],
             id: 'immersiveengineering:crafting/blastbrick_reinforced'
         }

--- a/kubejs/server_scripts/expert/recipes/mekanism/nucleosynthesizing.js
+++ b/kubejs/server_scripts/expert/recipes/mekanism/nucleosynthesizing.js
@@ -6,11 +6,11 @@ ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:expert/mekanism/nucleosynthesizing/';
     const recipes = [
         {
-            output: { item: 'emendatusenigmatica:brass_ingot' },
-            gasInput: { gas: 'mekanism:antimatter', amount: 5 },
+            output: { item: 'powah:steel_energized' },
+            gasInput: { gas: 'mekanism:antimatter', amount: 10000 },
             itemInput: { ingredient: { tag: 'forge:ingots/copper' } },
             duration: 500,
-            id: `${id_prefix}brass_ingot`
+            id: `${id_prefix}steel_energized`
         },
         {
             output: { item: 'minecraft:end_crystal' },

--- a/kubejs/server_scripts/expert/recipes/mekanism/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/mekanism/shaped.js
@@ -281,7 +281,7 @@ ServerEvents.recipes((event) => {
             output: 'mekanism:module_gravitational_modulating_unit',
             pattern: ['ABA', 'CDC', 'FEF'],
             key: {
-                A: '#forge:ingots/brass',
+                A: '#forge:ingots/energized_steel',
                 B: 'ars_elemental:air_focus',
                 C: '#forge:plates/aluminum',
                 D: 'modularrouters:augment_core',

--- a/kubejs/server_scripts/expert/recipes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/expert/recipes/naturesaura/tree_ritual.js
@@ -317,10 +317,10 @@ ServerEvents.recipes((event) => {
                 '#forge:storage_blocks/soul_steel',
                 'spirit:soul_slate',
                 'spirit:soul_slate',
-                '#forge:gears/brass',
-                '#forge:gears/brass',
-                '#forge:gears/brass',
-                '#forge:gears/brass'
+                '#forge:storage_blocks/energized_steel',
+                '#forge:storage_blocks/energized_steel',
+                '#forge:storage_blocks/energized_steel',
+                '#forge:storage_blocks/energized_steel'
             ],
             time: 120,
             sapling: 'ars_nouveau:purple_archwood_sapling',

--- a/kubejs/server_scripts/expert/recipes/occultism/ritual.js
+++ b/kubejs/server_scripts/expert/recipes/occultism/ritual.js
@@ -1090,14 +1090,14 @@ ServerEvents.recipes((event) => {
                 '#forge:storage_blocks/source',
                 '#forge:gears/aluminum',
 
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass',
 
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass'
             ],
             entity_to_sacrifice: {
@@ -1146,14 +1146,14 @@ ServerEvents.recipes((event) => {
                 '#forge:storage_blocks/source',
                 '#forge:gears/aluminum',
 
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass',
 
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass',
-                '#forge:ingots/energized_steel',
+                '#forge:ingots/brass',
                 'spirit:soul_glass'
             ],
             entity_to_sacrifice: {
@@ -1456,7 +1456,7 @@ ServerEvents.recipes((event) => {
             output: 'kubejs:teleport_end',
             activation_item: '#forge:gems/infused_ender',
             inputs: [
-                '#forge:ingots/brass',
+                '#forge:ingots/energized_steel',
                 'naturesaura:gold_leaf',
                 '#forge:essences/air',
                 'naturesaura:gold_leaf',

--- a/kubejs/server_scripts/expert/recipes/occultism/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/occultism/shaped.js
@@ -24,11 +24,11 @@ ServerEvents.recipes((event) => {
             id: `occultism:crafting/golden_sacrificial_bowl`
         },
         {
-            output: '5x occultism:wormhole_frame',
-            pattern: ['ABA', 'BAB', 'ABA'],
+            output: 'occultism:wormhole_frame',
+            pattern: ['BBB', 'BAB', 'BBB'],
             key: {
                 A: 'occultism:otherstone_frame',
-                B: '#forge:ingots/brass'
+                B: '#forge:nuggets/brass'
             },
             id: `occultism:crafting/wormhole_frame`
         }

--- a/kubejs/server_scripts/expert/recipes/occultism/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/occultism/shaped.js
@@ -28,7 +28,7 @@ ServerEvents.recipes((event) => {
             pattern: ['ABA', 'BAB', 'ABA'],
             key: {
                 A: 'occultism:otherstone_frame',
-                B: '#forge:ingots/energized_steel'
+                B: '#forge:ingots/brass'
             },
             id: `occultism:crafting/wormhole_frame`
         }

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/shaped.js
@@ -251,7 +251,7 @@ ServerEvents.recipes((event) => {
             pattern: ['ABA', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board'
             },
@@ -262,7 +262,7 @@ ServerEvents.recipes((event) => {
             pattern: [' E ', 'AB ', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pressure_tube',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'supplementaries:crystal_display'
@@ -274,7 +274,7 @@ ServerEvents.recipes((event) => {
             pattern: ['EAA', ' BA', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'quark:rainbow_rune'
@@ -286,7 +286,7 @@ ServerEvents.recipes((event) => {
             pattern: ['EAA', ' BA', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'pneumaticcraft:drill_bit_diamond'
@@ -298,7 +298,7 @@ ServerEvents.recipes((event) => {
             pattern: ['EAA', ' BA', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'create:brass_hand'
@@ -310,7 +310,7 @@ ServerEvents.recipes((event) => {
             pattern: ['AAE', 'AB ', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/energized_steel',
+                B: '#forge:ingots/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'create:brass_hand'

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/shaped.js
@@ -251,7 +251,7 @@ ServerEvents.recipes((event) => {
             pattern: ['ABA', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/brass',
+                B: '#forge:plates/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board'
             },
@@ -262,7 +262,7 @@ ServerEvents.recipes((event) => {
             pattern: [' E ', 'AB ', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pressure_tube',
-                B: '#forge:ingots/brass',
+                B: '#forge:gears/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'supplementaries:crystal_display'
@@ -271,10 +271,10 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'pneumaticcraft:assembly_laser',
-            pattern: ['EAA', ' BA', 'CDC'],
+            pattern: ['EBB', ' AB', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/brass',
+                B: '#forge:rods/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'quark:rainbow_rune'
@@ -283,10 +283,10 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'pneumaticcraft:assembly_drill',
-            pattern: ['EAA', ' BA', 'CDC'],
+            pattern: ['EBB', ' AB', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/brass',
+                B: '#forge:rods/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'pneumaticcraft:drill_bit_diamond'
@@ -295,10 +295,10 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'pneumaticcraft:assembly_io_unit_import',
-            pattern: ['EAA', ' BA', 'CDC'],
+            pattern: ['EBB', ' AB', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/brass',
+                B: '#forge:rods/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'create:brass_hand'
@@ -307,10 +307,10 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'pneumaticcraft:assembly_io_unit_export',
-            pattern: ['AAE', 'AB ', 'CDC'],
+            pattern: ['BBE', 'BA ', 'CDC'],
             key: {
                 A: 'pneumaticcraft:pneumatic_cylinder',
-                B: '#forge:ingots/brass',
+                B: '#forge:rods/brass',
                 C: '#forge:ingots/compressed_iron',
                 D: 'pneumaticcraft:printed_circuit_board',
                 E: 'create:brass_hand'

--- a/kubejs/server_scripts/expert/recipes/powah/energizing.js
+++ b/kubejs/server_scripts/expert/recipes/powah/energizing.js
@@ -5,10 +5,10 @@ ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:expert/powah/energizing/';
     const recipes = [
         {
-            output: '3x powah:steel_energized',
+            output: '3x emendatusenigmatica:brass_ingot',
             inputs: ['#forge:dusts/aluminum', '#forge:dusts/aluminum', '#forge:dusts/copper', '#forge:essences/earth'],
             energy: '100000',
-            id: `${id_prefix}steel_energized`
+            id: `${id_prefix}brass_ingot`
         },
         {
             output: '2x powah:crystal_niotic',

--- a/kubejs/server_scripts/expert/recipes/spirit/soul_engulfing.js
+++ b/kubejs/server_scripts/expert/recipes/spirit/soul_engulfing.js
@@ -17,7 +17,7 @@ ServerEvents.recipes((event) => {
                         ['ABA', 'B&B', 'ABA']
                     ],
                     keys: {
-                        A: { block: 'powah:energized_steel_block' },
+                        A: { block: '#forge:storage_blocks/brass' },
                         B: { block: '#forge:storage_blocks/source' },
                         C: { block: 'minecraft:wither_skeleton_skull' }
                     }
@@ -38,7 +38,7 @@ ServerEvents.recipes((event) => {
                         ['ABA', 'B&B', 'ABA']
                     ],
                     keys: {
-                        A: { block: 'powah:energized_steel_block' },
+                        A: { block: '#forge:storage_blocks/brass' },
                         B: { block: '#forge:storage_blocks/source' },
                         C: { block: 'minecraft:wither_skeleton_skull' }
                     }


### PR DESCRIPTION
- Orichalcum (renamed Energized Steel) and Aetheric Brass (renamed Brass) have swapped places. Orichalcum now uses Brass as the base and Aetheric Brass uses Energized Steel. This is largely to allow use of plates/rods/gears for Orichalcum without needing to generate new resources. 
- Change to Enchanting Apparatus and Arcane Core
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/633a4aa5-f727-4ce0-aaab-c5d232100ef9)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/b770c8a8-78a6-4d7b-b773-d0afb39e8817)
- Many other similar shifts from Orichalcum ingots to gears/rods/plates