### PR TITLE
Disables quark food tooltip

### DIFF
--- a/config/configswapper/expert/config/quark-common.toml
+++ b/config/configswapper/expert/config/quark-common.toml
@@ -1204,7 +1204,7 @@
 		"Shulker Tooltips" = true
 		"Map Require Shift" = false
 		"Fuel Time Divisor" = 200
-		"Food Tooltips" = true
+		"Food Tooltips" = false
 		"Show Saturation" = true
 		"Map Tooltips" = true
 		"Enchanting Stacks" = ["minecraft:diamond_sword", "minecraft:diamond_pickaxe", "minecraft:diamond_shovel", "minecraft:diamond_axe", "minecraft:diamond_hoe", "minecraft:diamond_helmet", "minecraft:diamond_chestplate", "minecraft:diamond_leggings", "minecraft:diamond_boots", "minecraft:shears", "minecraft:bow", "minecraft:fishing_rod", "minecraft:crossbow", "minecraft:trident", "minecraft:elytra", "quark:pickarang"]

--- a/config/configswapper/normal/config/quark-common.toml
+++ b/config/configswapper/normal/config/quark-common.toml
@@ -1209,7 +1209,7 @@
 		#If set to false, item attributes will show in white or red if they're negative values.
 		"Show Upgrade Status" = true
 		"Animate Up Down Arrows" = true
-		"Food Tooltips" = true
+		"Food Tooltips" = false
 		"Show Saturation" = true
 		"Map Tooltips" = true
 		"Enchanting Stacks" = ["minecraft:diamond_sword", "minecraft:diamond_pickaxe", "minecraft:diamond_shovel", "minecraft:diamond_axe", "minecraft:diamond_hoe", "minecraft:diamond_helmet", "minecraft:diamond_chestplate", "minecraft:diamond_leggings", "minecraft:diamond_boots", "minecraft:shears", "minecraft:bow", "minecraft:fishing_rod", "minecraft:crossbow", "minecraft:trident", "minecraft:elytra", "quark:pickarang"]


### PR DESCRIPTION
Appleskin does this much better(includes saturation), no reason for quark to add a 2nd food value