### PR TITLE
e9e advancements fix and potion tweak

### DIFF
--- a/config/jei/recipe-category-sort-order.ini
+++ b/config/jei/recipe-category-sort-order.ini
@@ -224,3 +224,6 @@ hexerei:book_of_shadows_dye
 hexerei:crow_flute_dye
 jeed:effect_info
 some_assembly_required:sandwiching_station
+lychee:item_exploding/minecraft/default
+lychee:item_inside/minecraft/default
+lychee:lightning_channeling/minecraft/default

--- a/kubejs/server_scripts/expert/advancements/the_bumblezone.js
+++ b/kubejs/server_scripts/expert/advancements/the_bumblezone.js
@@ -71,12 +71,6 @@ ServerEvents.highPriorityData((event) => {
                         target_advancement: 'the_bumblezone:the_bumblezone/the_queens_desire/otherworldly_mites'
                     }
                 },
-                target_advancement_done_9: {
-                    trigger: 'the_bumblezone:target_advancement_done',
-                    conditions: {
-                        target_advancement: 'the_bumblezone:the_bumblezone/the_queens_desire/peak_inefficiency'
-                    }
-                },
                 target_advancement_done_10: {
                     trigger: 'the_bumblezone:target_advancement_done',
                     conditions: {

--- a/kubejs/startup_scripts/base/brewing_registry.js
+++ b/kubejs/startup_scripts/base/brewing_registry.js
@@ -209,7 +209,7 @@ MoreJSEvents.registerPotionBrewing((event) => {
             output: 'minecraft:slowness'
         },
         {
-            reagent: 'byg:baobab_fruit',
+            reagent: 'thermal:spinach_block',
             input: 'minecraft:awkward',
             output: 'apotheosis:resistance'
         },


### PR DESCRIPTION
Resistance potions now take a crate of spinach. 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/56c33169-284e-4c53-bd79-c5ab13069b8d)


Fixes advancements for Bumblezone, Queen's Desire. 