### PR TITLE
E9E Power transfer adjustments

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   Stable Wormholes may now be reset in a crafting table [\#487](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/487) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Add many items to Mekanism's Painting system [\#494](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/494) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Apotheosis bosses largely reverted to new defaults. Remaining bosses brought more in line with the new balancing. [\#495](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/495) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Apotheosis gems that were previously modified have been rebalanced to closer match the new defaults. [\#496](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/496) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/config/configswapper/expert/config/starbunclemania-server.toml
+++ b/config/configswapper/expert/config/starbunclemania-server.toml
@@ -17,7 +17,7 @@
 	starbucket_threshold = 250
 	#Threshold rate of the energy starbuncles, lower this if you need them to check and fill more often.
 	#Range: > 1
-	starbattery_threshold = 1000
+	starbattery_threshold = 250
 	#Threshold rate of the gas starbuncles, lower this if you need them to check and fill more often.
 	#Range: > 1
 	starballoon_threshold = 250

--- a/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
@@ -11,7 +11,7 @@ sourceConversion = 400.0
 	powerBuffer = 120000
 	#Max amount of power transfer for the Dim type per tick
 	#Range: > 0
-	maxPowertransfer = 500
+	maxPowertransfer = 120000
 	#Range the Dim type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -31,7 +31,7 @@ sourceConversion = 400.0
 	powerBuffer = 480000
 	#Max amount of power transfer for the Bright type per tick
 	#Range: > 0
-	maxPowertransfer = 4000
+	maxPowertransfer = 480000
 	#Range the Bright type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -51,7 +51,7 @@ sourceConversion = 400.0
 	powerBuffer = 960000
 	#Max amount of power transfer for the Iridescent type per tick
 	#Range: > 0
-	maxPowertransfer = 16000
+	maxPowertransfer = 960000
 	#Range the Iridescent type can connect to Source containers
 	#Range: > 0
 	range = 8

--- a/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
@@ -8,10 +8,10 @@ sourceConversion = 400.0
 ["Dim type"]
 	#Power Buffer size  of the Dim type
 	#Range: > 0
-	powerBuffer = 120000
+	powerBuffer = 2048000
 	#Max amount of power transfer for the Dim type per tick
 	#Range: > 0
-	maxPowertransfer = 120000
+	maxPowertransfer = 2048000
 	#Range the Dim type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -28,10 +28,10 @@ sourceConversion = 400.0
 ["Bright type"]
 	#Power Buffer size  of the Bright type
 	#Range: > 0
-	powerBuffer = 480000
+	powerBuffer = 2048000
 	#Max amount of power transfer for the Bright type per tick
 	#Range: > 0
-	maxPowertransfer = 480000
+	maxPowertransfer = 2048000
 	#Range the Bright type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -48,10 +48,10 @@ sourceConversion = 400.0
 ["Iridescent type"]
 	#Power Buffer size  of the Iridescent type
 	#Range: > 0
-	powerBuffer = 960000
+	powerBuffer = 2048000
 	#Max amount of power transfer for the Iridescent type per tick
 	#Range: > 0
-	maxPowertransfer = 960000
+	maxPowertransfer = 2048000
 	#Range the Iridescent type can connect to Source containers
 	#Range: > 0
 	range = 8

--- a/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/expert/serverconfig/enigmaticunity-server.toml
@@ -8,10 +8,10 @@ sourceConversion = 400.0
 ["Dim type"]
 	#Power Buffer size  of the Dim type
 	#Range: > 0
-	powerBuffer = 2048000
+	powerBuffer = 240000
 	#Max amount of power transfer for the Dim type per tick
 	#Range: > 0
-	maxPowertransfer = 2048000
+	maxPowertransfer = 240000
 	#Range the Dim type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -28,10 +28,10 @@ sourceConversion = 400.0
 ["Bright type"]
 	#Power Buffer size  of the Bright type
 	#Range: > 0
-	powerBuffer = 2048000
+	powerBuffer = 960000
 	#Max amount of power transfer for the Bright type per tick
 	#Range: > 0
-	maxPowertransfer = 2048000
+	maxPowertransfer = 960000
 	#Range the Bright type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -48,10 +48,10 @@ sourceConversion = 400.0
 ["Iridescent type"]
 	#Power Buffer size  of the Iridescent type
 	#Range: > 0
-	powerBuffer = 2048000
+	powerBuffer = 1920000
 	#Max amount of power transfer for the Iridescent type per tick
 	#Range: > 0
-	maxPowertransfer = 2048000
+	maxPowertransfer = 1920000
 	#Range the Iridescent type can connect to Source containers
 	#Range: > 0
 	range = 8

--- a/config/configswapper/normal/config/starbunclemania-server.toml
+++ b/config/configswapper/normal/config/starbunclemania-server.toml
@@ -17,7 +17,7 @@
 	starbucket_threshold = 250
 	#Threshold rate of the energy starbuncles, lower this if you need them to check and fill more often.
 	#Range: > 1
-	starbattery_threshold = 1000
+	starbattery_threshold = 250
 	#Threshold rate of the gas starbuncles, lower this if you need them to check and fill more often.
 	#Range: > 1
 	starballoon_threshold = 250

--- a/config/configswapper/normal/serverconfig/enigmaticunity-server.toml
+++ b/config/configswapper/normal/serverconfig/enigmaticunity-server.toml
@@ -11,7 +11,7 @@ sourceConversion = 250.0
 	powerBuffer = 120000
 	#Max amount of power transfer for the Dim type per tick
 	#Range: > 0
-	maxPowertransfer = 500
+	maxPowertransfer = 120000
 	#Range the Dim type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -31,7 +31,7 @@ sourceConversion = 250.0
 	powerBuffer = 480000
 	#Max amount of power transfer for the Bright type per tick
 	#Range: > 0
-	maxPowertransfer = 4000
+	maxPowertransfer = 480000
 	#Range the Bright type can connect to Source containers
 	#Range: > 0
 	range = 8
@@ -51,7 +51,7 @@ sourceConversion = 250.0
 	powerBuffer = 960000
 	#Max amount of power transfer for the Iridescent type per tick
 	#Range: > 0
-	maxPowertransfer = 16000
+	maxPowertransfer = 960000
 	#Range the Iridescent type can connect to Source containers
 	#Range: > 0
 	range = 8

--- a/kubejs/server_scripts/base/recipes/apotheosis/gems/the_nether.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/gems/the_nether.js
@@ -13,45 +13,82 @@ ServerEvents.highPriorityData((event) => {
             bonuses: [
                 {
                     type: 'apotheosis:attribute',
-                    gem_class: { key: 'heavy_weapon', types: ['heavy_weapon'] },
+                    gem_class: {
+                        key: 'heavy_weapon',
+                        types: ['heavy_weapon']
+                    },
                     attribute: 'apotheosis:fire_damage',
                     operation: 'ADDITION',
                     values: {
-                        rare: { min: 6.0, steps: 3, step: 0.5 },
-                        epic: { min: 8.0, steps: 3, step: 0.5 },
-                        mythic: { min: 10.0, steps: 4, step: 0.5 },
-                        ancient: { min: 13.5, steps: 6, step: 0.5 }
+                        rare: 6,
+                        epic: 8,
+                        mythic: 10,
+                        ancient: 12.5
+                    }
+                },
+                {
+                    type: 'apotheosis:mob_effect',
+                    gem_class: {
+                        key: 'light_weapon',
+                        types: ['sword', 'trident']
+                    },
+                    mob_effect: 'apotheosis:detonation',
+                    target: 'attack_target',
+                    values: {
+                        mythic: {
+                            duration: 100,
+                            amplifier: 0,
+                            cooldown: 1200
+                        },
+                        ancient: {
+                            duration: 100,
+                            amplifier: 1,
+                            cooldown: 1200
+                        }
+                    }
+                },
+                {
+                    type: 'apotheosis:enchantment',
+                    gem_class: {
+                        key: 'chestplate',
+                        types: ['chestplate']
+                    },
+                    enchantment: 'minecraft:fire_protection',
+                    values: {
+                        rare: 1,
+                        epic: 1,
+                        mythic: 2,
+                        ancient: 2
+                    }
+                },
+                {
+                    type: 'apotheosis:enchantment',
+                    gem_class: {
+                        key: 'breaker',
+                        types: ['shovel', 'pickaxe']
+                    },
+                    enchantment: 'minecraft:efficiency',
+                    values: {
+                        rare: 1,
+                        epic: 1,
+                        mythic: 2,
+                        ancient: 2
                     }
                 },
                 {
                     type: 'apotheosis:attribute',
-                    gem_class: { key: 'helmet', types: ['helmet'] },
+                    gem_class: {
+                        key: 'helmet',
+                        types: ['helmet']
+                    },
                     attribute: 'apotheosis:fire_damage',
                     operation: 'MULTIPLY_TOTAL',
                     values: {
-                        rare: { min: 0.5, steps: 3, step: 0.025 },
-                        epic: { min: 0.6, steps: 3, step: 0.025 },
-                        mythic: { min: 0.75, steps: 4, step: 0.025 },
-                        ancient: { min: 0.9, steps: 5, step: 0.02 }
+                        rare: 0.5,
+                        epic: 0.625,
+                        mythic: 0.75,
+                        ancient: 0.9
                     }
-                },
-                {
-                    type: 'apotheosis:enchantment',
-                    gem_class: { key: 'light_weapon', types: ['sword', 'trident'] },
-                    enchantment: 'minecraft:fire_aspect',
-                    values: { rare: 1, epic: 2, mythic: 3, ancient: 4 }
-                },
-                {
-                    type: 'apotheosis:enchantment',
-                    gem_class: { key: 'chestplate', types: ['chestplate'] },
-                    enchantment: 'minecraft:fire_protection',
-                    values: { rare: 1, epic: 1, mythic: 2, ancient: 2 }
-                },
-                {
-                    type: 'apotheosis:enchantment',
-                    gem_class: { key: 'breaker', types: ['shovel', 'pickaxe'] },
-                    enchantment: 'minecraft:efficiency',
-                    values: { rare: 1, epic: 1, mythic: 2, ancient: 2 }
                 }
             ]
         }

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/cnb.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/cnb.js
@@ -17,6 +17,7 @@ ServerEvents.highPriorityData((event) => {
             weight: 85,
             quality: 0,
             entities: ['cnb:sporeling'],
+            dimensions: ['twilightforest:twilight_forest'],
             valid_gear_sets: ['#miniboss/sporeling'],
             dimensions: [],
             affixed: false,


### PR DESCRIPTION
- Enigmatic Unity Crystals no longer rate limit power transfer. This was preventing them from working nicely with Starbuncles. They still only produce as fast as the old rate limits, however.
- Power storage in the crystals is also buffed. This helps starbies be able to carry more if they have to run a long distance to pick up power. 
- Starbuncle power threshold has been lowered. This allows the starby pick up smaller amounts of power and leave with it. A higher value was leading them to void power in situations where they couldn't pull the threshold value in 1 tick.
- Apotheosis gems are re-balanced following Apotheosis' update as well. 
- Miniboss sporelings now only spawn in twilight forest. Their reactive armor was interacting poorly in the nether if they fell into lava.

