### PR TITLE
E9E Feedback Corrections

### DIFF
--- a/kubejs/server_scripts/expert/recipes/enigmatica/crushing_tiers.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/crushing_tiers.js
@@ -20,7 +20,7 @@ ServerEvents.recipes((event) => {
         {
             outputs: { primary: 'occultism:crushed_end_stone' },
             input: 'minecraft:end_stone',
-            crushing_tier: 3,
+            crushing_tier: 2,
             id_suffix: 'crushed_end_stone_from_end_stone'
         },
         {


### PR DESCRIPTION
- End Stone may now be crushed as a Tier 2 material, allowing to be crafted via Crush or Millstone