### PR TITLE
Remove faulty drawer recipes

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Fixed Bugs
 
+-   Removed faulty drawer recipes [\#534](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/534) ([MuteTiefling](https://github.com/MuteTiefling))
+
 ### Removed Mods
 
 -   ***

--- a/kubejs/client_scripts/constants/jei_hidden_disabled.js
+++ b/kubejs/client_scripts/constants/jei_hidden_disabled.js
@@ -852,7 +852,8 @@ jei.expert.recipes.hidden = [
             'ars_elemental:air_focus',
             'ars_elemental:necrotic_focus',
             'ars_nouveau:summon_focus',
-            'ars_nouveau:shapers_focus'
+            'ars_nouveau:shapers_focus',
+            'ars_nouveau:relay_splitter'
         ]
     }
 ];

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -81,6 +81,10 @@ ServerEvents.recipes((event) => {
 
         { id: /emendatusenigmatica:gear\/from_ingot_press/ },
 
+        { id: 'functionalstorage:oak_drawer_alternate_x1' },
+        { id: 'functionalstorage:oak_drawer_alternate_x2' },
+        { id: 'functionalstorage:oak_drawer_alternate_x4' },
+
         { id: 'hexerei:black_dye_from_pestle_and_mortar' },
         { id: 'hexerei:broom_netherite_tip_from_mixing_cauldron' },
 

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/patchouli_safe_remove.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/patchouli_safe_remove.js
@@ -35,7 +35,8 @@ ServerEvents.recipes((event) => {
             { id: 'ars_elemental:air_focus', output: 'ars_elemental:air_focus' },
             { id: 'ars_elemental:necrotic_focus', output: 'ars_elemental:necrotic_focus' },
             { id: 'ars_nouveau:summon_focus', output: 'ars_nouveau:summon_focus' },
-            { id: 'ars_nouveau:shapers_focus', output: 'ars_nouveau:shapers_focus' }
+            { id: 'ars_nouveau:shapers_focus', output: 'ars_nouveau:shapers_focus' },
+            { id: 'ars_nouveau:relay_splitter', output: 'ars_nouveau:relay_splitter' }
         ],
         imbuement: [
             { id: 'ars_nouveau:imbuement_lapis', output: 'emendatusenigmatica:source_gem' },

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
@@ -156,6 +156,27 @@ ServerEvents.recipes((event) => {
                 B: 'ars_nouveau:spell_prism'
             },
             id: `ars_nouveau:void_prism`
+        },
+        {
+            output: 'ars_nouveau:relay',
+            pattern: ['A A', 'BCB', 'A A'],
+            key: {
+                A: '#forge:nuggets/gold',
+                B: '#forge:ingots/gold',
+                C: '#forge:storage_blocks/source'
+            },
+            id: `ars_nouveau:relay`
+        },
+        {
+            output: 'ars_nouveau:relay_splitter',
+            pattern: ['ADA', 'BCB', 'ADA'],
+            key: {
+                A: '#forge:nuggets/gold',
+                B: '#forge:ingots/gold',
+                C: '#forge:storage_blocks/source',
+                D: 'ae2:charged_certus_quartz_crystal'
+            },
+            id: `${id_prefix}relay_splitter`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/shapeless.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/shapeless.js
@@ -61,6 +61,11 @@ ServerEvents.recipes((event) => {
             output: '2x ars_nouveau:end_fiber',
             inputs: ['ars_nouveau:magebloom_fiber', 'ars_nouveau:magebloom_fiber', '#forge:dusts/end_stone'],
             id: 'ars_nouveau:end_fiber'
+        },
+        {
+            output: 'ars_nouveau:relay_splitter',
+            inputs: ['ars_nouveau:relay', 'ae2:charged_certus_quartz_crystal', 'ae2:charged_certus_quartz_crystal'],
+            id: `${id_prefix}relay_splitter`
         }
     ];
 


### PR DESCRIPTION
The recipes in question allow any non vanilla plank to be used to make an oak drawer. It's not working in the pack, possibly a conflict with the various wood compat mods. 

Simpler to just remove them. Vanilla trees are readily available from the market.