### PR TITLE
Expert improvements

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   Powah Capacitors are now cheaper to craft. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Powah Energy Cables are cheaper to upgrade. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Spawner Rifts will now spawn Wilden as part of the waves. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
--   Create Rolling now uses rods to make wires. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Create Rolling now uses rods to make wires. Wires made from ingots in other machines now produce more to compensate. [\#553](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/553) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   Removed faulty drawer recipes [\#536](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/536) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fix broken ore processing recipes [\#552](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/552) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Hide visible Expert Storage quest. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Slag glass is now made from slag gravel to avoid issues with Create smelting. [\#553](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/553) ([MuteTiefling](https://
 
 ### Removed Mods
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   Powah Capacitors are now cheaper to craft. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Powah Energy Cables are cheaper to upgrade. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Spawner Rifts will now spawn Wilden as part of the waves. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Create Rolling now uses rods to make wires. [\#548](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/548) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/config/configswapper/expert/config/ars_scalaes/glyph_expand.toml
+++ b/config/configswapper/expert/config/ars_scalaes/glyph_expand.toml
@@ -1,0 +1,31 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 10
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 1
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Enable a timer on the resize effects. Target will return to original size when potion effect is removed.
+	limitedSizeTime = true
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 120
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 60
+	#Define the maximum size that can be reached.
+	#Range: 1.1 ~ 30.0
+	max_scaling = 15.0
+

--- a/config/configswapper/expert/config/ars_scalaes/glyph_resize.toml
+++ b/config/configswapper/expert/config/ars_scalaes/glyph_resize.toml
@@ -1,0 +1,37 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 10
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 1
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Enable a timer on the resize effects. Target will return to original size when potion effect is removed.
+	limitedSizeTime = true
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 120
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 60
+	#Define the minimum size that can be reached.
+	#Range: 0.01 ~ 1.0
+	min_scaling = 0.5
+	#Define the maximum size that can be reached.
+	#Range: 1.1 ~ 30.0
+	max_scaling = 7.0
+	#Define the factor of the amplification -> size conversion. The value is doubled for shrinking.
+	#Range: 1.0 ~ 10.0
+	scaling_factor = 5.0
+

--- a/config/configswapper/expert/config/ars_scalaes/glyph_shrink.toml
+++ b/config/configswapper/expert/config/ars_scalaes/glyph_shrink.toml
@@ -1,0 +1,31 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 10
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 1
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Enable a timer on the resize effects. Target will return to original size when potion effect is removed.
+	limitedSizeTime = true
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 120
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 60
+	#Define the minimum size that can be reached.
+	#Range: 0.01 ~ 1.0
+	min_scaling = 0.2
+

--- a/config/configswapper/normal/config/ars_scalaes/glyph_expand.toml
+++ b/config/configswapper/normal/config/ars_scalaes/glyph_expand.toml
@@ -1,0 +1,31 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 100
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 3
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Enable a timer on the resize effects. Target will return to original size when potion effect is removed.
+	limitedSizeTime = true
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 120
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 60
+	#Define the maximum size that can be reached.
+	#Range: 1.1 ~ 30.0
+	max_scaling = 15.0
+

--- a/config/configswapper/normal/config/ars_scalaes/glyph_resize.toml
+++ b/config/configswapper/normal/config/ars_scalaes/glyph_resize.toml
@@ -1,0 +1,37 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 100
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 2
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Enable a timer on the resize effects. Target will return to original size when potion effect is removed.
+	limitedSizeTime = true
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 120
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 60
+	#Define the minimum size that can be reached.
+	#Range: 0.01 ~ 1.0
+	min_scaling = 0.5
+	#Define the maximum size that can be reached.
+	#Range: 1.1 ~ 30.0
+	max_scaling = 7.0
+	#Define the factor of the amplification -> size conversion. The value is doubled for shrinking.
+	#Range: 1.0 ~ 10.0
+	scaling_factor = 5.0
+

--- a/config/configswapper/normal/config/ars_scalaes/glyph_shrink.toml
+++ b/config/configswapper/normal/config/ars_scalaes/glyph_shrink.toml
@@ -1,0 +1,31 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 100
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 3
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Enable a timer on the resize effects. Target will return to original size when potion effect is removed.
+	limitedSizeTime = true
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 120
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 60
+	#Define the minimum size that can be reached.
+	#Range: 0.01 ~ 1.0
+	min_scaling = 0.2
+

--- a/kubejs/client_scripts/constants/jei_hidden_disabled.js
+++ b/kubejs/client_scripts/constants/jei_hidden_disabled.js
@@ -252,8 +252,9 @@ jei.normal.gases.hidden = [];
 
 // Expert
 jei.expert.items.disabled = [
-    /computercraft/,
-    /rftoolsbuilder/,
+    /computercraft:/,
+    /rftoolsbuilder:/,
+    /shrink:/,
 
     'ae2:charger',
     'ae2:vibration_chamber',

--- a/kubejs/server_scripts/base/recipes/createaddition/rolling.js
+++ b/kubejs/server_scripts/base/recipes/createaddition/rolling.js
@@ -13,9 +13,9 @@ ServerEvents.recipes((event) => {
 
         if (metal_properties[metal].wire) {
             recipes.push({
-                output: '2x immersiveengineering:wire_lead',
-                input: `forge:rods/${metal}`,
-                id: `${id_prefix}lead_wire`
+                output: `2x immersiveengineering:wire_${metal}`,
+                input: `#forge:rods/${metal}`,
+                id: `${id_prefix}${metal}_wire`
             });
         }
     });

--- a/kubejs/server_scripts/base/recipes/createaddition/rolling.js
+++ b/kubejs/server_scripts/base/recipes/createaddition/rolling.js
@@ -1,12 +1,6 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:base/createaddition/rolling/';
-    const recipes = [
-        {
-            output: '2x immersiveengineering:wire_copper',
-            input: '#forge:plates/copper',
-            id: `${id_prefix}copper_wire`
-        }
-    ];
+    const recipes = [];
 
     Object.keys(metal_properties).forEach((metal) => {
         if (metal_properties[metal].rod) {
@@ -14,6 +8,14 @@ ServerEvents.recipes((event) => {
                 output: `2x emendatusenigmatica:${metal}_rod`,
                 input: `#forge:ingots/${metal}`,
                 id: `${id_prefix}${metal}_rod`
+            });
+        }
+
+        if (metal_properties[metal].wire) {
+            recipes.push({
+                output: '2x immersiveengineering:wire_lead',
+                input: `forge:rods/${metal}`,
+                id: `${id_prefix}lead_wire`
             });
         }
     });

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -13,6 +13,7 @@ ServerEvents.recipes((event) => {
         { mod: 'densetrees' },
 
         { type: 'immersiveengineering:mineral_mix' },
+        { type: 'createaddition:rolling' },
 
         { output: /pendorite/ },
         { output: /emeraldite/ },
@@ -58,24 +59,19 @@ ServerEvents.recipes((event) => {
 
         { id: /createaddition:mixing\/biomass/ },
         { id: /createaddition:crafting\/.*spool/ },
-        { id: /createaddition:rolling\/.*_ingot/ },
         { id: 'createaddition:crafting/barbed_wire' },
         { id: 'createaddition:crafting/redstone_relay' },
         { id: 'createaddition:crafting/connector' },
+        { id: 'createaddition:crafting/accumulator_conversion' },
         { id: 'createaddition:compacting/seed_oil' },
         { id: 'createaddition:mixing/bioethanol' },
         { id: 'createaddition:mechanical_crafting/accumulator' },
         { id: 'createaddition:mechanical_crafting/tesla_coil' },
         { id: 'createaddition:mechanical_crafting/electric_motor' },
         { id: 'createaddition:mechanical_crafting/alternator' },
-        { id: 'createaddition:rolling/copper_plate' },
-        { id: 'createaddition:rolling/iron_plate' },
         { id: 'createaddition:metalpress/wire_iron' },
-        { id: 'createaddition:rolling/gold_plate' },
         { id: 'createaddition:metalpress/wire_gold' },
-        { id: 'createaddition:rolling/straw' },
         { id: 'createaddition:compat/ae2/charged_certus_quartz' },
-        { id: 'createaddition:crafting/accumulator_conversion' },
         { id: 'createaddition:compat/immersiveengineering/crushing/coal_coke' },
         { id: 'createaddition:compat/immersiveengineering/crushing/coke_block' },
 
@@ -93,7 +89,7 @@ ServerEvents.recipes((event) => {
         { id: 'industrialforegoing:stonework_generate/andesite' },
         { id: 'industrialforegoing:laser_drill_ore/ores/cinnabar' },
 
-        { id: /immersiveengineering:metalpress\/(gear|rod|plate)_/ },
+        { id: /immersiveengineering:metalpress\/(gear|rod|plate|wire)_/ },
         { id: 'immersiveengineering:crafting/coal_coke_to_coke' },
         { id: 'immersiveengineering:refinery/biodiesel' },
         { id: 'immersiveengineering:crusher/slag' },
@@ -101,6 +97,7 @@ ServerEvents.recipes((event) => {
         { id: 'immersiveengineering:crusher/sandstone' },
         { id: 'immersiveengineering:crusher/bone_meal' },
         { id: 'immersiveengineering:crusher/red_sandstone' },
+        { id: 'immersiveengineering:smelting/slag_glass' },
 
         { id: /mekanism:enriching\/dye/ },
         { id: /mekanism:compat\/byg\/dye/ },

--- a/kubejs/server_scripts/base/recipes/immersiveengineering/metalpress.js
+++ b/kubejs/server_scripts/base/recipes/immersiveengineering/metalpress.js
@@ -34,6 +34,16 @@ ServerEvents.recipes((event) => {
                 id: `${id_prefix}${metal}_rod`
             });
         }
+
+        if (metal_properties[metal].wire) {
+            recipes.push({
+                output: `4x immersiveengineering:wire_${metal}`,
+                mold: 'immersiveengineering:mold_wire',
+                input: `#forge:ingots/${metal}`,
+                energy: 2400,
+                id: `${id_prefix}${metal}_wire`
+            });
+        }
     });
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/base/recipes/minecraft/smelting.js
+++ b/kubejs/server_scripts/base/recipes/minecraft/smelting.js
@@ -48,6 +48,12 @@ ServerEvents.recipes((event) => {
             output: 'minecraft:purple_stained_glass',
             xp: 0.5,
             id: `byg:purple_glass_from_sand`
+        },
+        {
+            input: 'immersiveengineering:slag_gravel',
+            output: 'immersiveengineering:slag_glass',
+            xp: 0.5,
+            id: `${id_prefix}slag_glass`
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/thermal/press.js
+++ b/kubejs/server_scripts/base/recipes/thermal/press.js
@@ -82,7 +82,7 @@ ServerEvents.recipes((event) => {
 
         if (metal_properties[metal].wire) {
             recipes.push({
-                result: [{ item: `immersiveengineering:wire_${metal}`, count: 2 }],
+                result: [{ item: `immersiveengineering:wire_${metal}`, count: 4 }],
                 ingredient: [{ tag: `forge:ingots/${metal}` }, { item: 'immersiveengineering:mold_wire' }],
                 energy: 2400,
                 id: `${id_prefix}wire_${metal}`

--- a/kubejs/server_scripts/base/recipes/thermal/refinery.js
+++ b/kubejs/server_scripts/base/recipes/thermal/refinery.js
@@ -3,15 +3,6 @@ ServerEvents.recipes((event) => {
 
     const recipes = [
         {
-            ingredient: { fluid: 'industrialforegoing:latex', amount: 900 },
-            result: [
-                { fluid: 'minecraft:water', amount: 100 },
-                { item: 'thermal:rubber', chance: 1.0 }
-            ],
-            energy: 6000,
-            id: `${id_prefix}rubber`
-        },
-        {
             ingredient: { fluid: 'pneumaticcraft:oil', amount: 100 },
             result: [
                 { fluid: 'pneumaticcraft:diesel', amount: 50 },

--- a/kubejs/server_scripts/expert/loot_tables/chests/enigmatica/ars_nouveau_glyph_cache.js
+++ b/kubejs/server_scripts/expert/loot_tables/chests/enigmatica/ars_nouveau_glyph_cache.js
@@ -58,6 +58,9 @@ ServerEvents.genericLootTables((event) => {
             pool.addItem('ars_elemental:glyph_not_aerial_filter', 1, 1);
             pool.addItem('ars_elemental:glyph_not_insect_filter', 1, 1);
             pool.addItem('ars_elemental:glyph_not_aquatic_filter', 1, 1);
+            pool.addItem('ars_scalaes:glyph_shrink', 1, 1);
+            pool.addItem('ars_scalaes:glyph_expand', 1, 1);
+            pool.addItem('ars_scalaes:glyph_resize', 1, 1);
         });
     });
 
@@ -68,7 +71,6 @@ ServerEvents.genericLootTables((event) => {
             pool.addItem('ars_nouveau:glyph_infuse', 1, 1);
             pool.addItem('starbunclemania:glyph_pickup_fluid', 1, 1);
             pool.addItem('starbunclemania:glyph_place_fluid', 1, 1);
-            pool.addItem('ars_scalaes:glyph_resize', 1, 1);
             pool.addItem('toomanyglyphs:glyph_filter_is_mature', 1, 1);
             pool.addItem('toomanyglyphs:glyph_chaining', 1, 1);
             pool.addItem('toomanyglyphs:glyph_filter_is_baby', 1, 1);
@@ -103,8 +105,6 @@ ServerEvents.genericLootTables((event) => {
         table.addPool((pool) => {
             pool.rolls = 1.0;
 
-            pool.addItem('ars_scalaes:glyph_shrink', 1, 1);
-            pool.addItem('ars_scalaes:glyph_expand', 1, 1);
             pool.addItem('ars_nouveau:glyph_linger', 1, 1);
             pool.addItem('ars_nouveau:glyph_summon_vex', 1, 1);
             pool.addItem('ars_nouveau:glyph_wall', 1, 1);

--- a/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/death_tome.js
+++ b/kubejs/server_scripts/expert/loot_tables/entities/twilightforest/death_tome.js
@@ -65,6 +65,10 @@ ServerEvents.entityLootTables((event) => {
             pool.addItem('toomanyglyphs:glyph_lay_on_hands', 2);
             pool.addItem('toomanyglyphs:glyph_ray', 2);
             pool.addItem('toomanyglyphs:glyph_reverse_direction', 2);
+
+            pool.addItem('ars_scalaes:glyph_shrink', 2);
+            pool.addItem('ars_scalaes:glyph_expand', 2);
+            pool.addItem('ars_scalaes:glyph_resize', 2);
         });
     });
 });

--- a/kubejs/server_scripts/expert/recipes/byg/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/byg/shaped.js
@@ -1,0 +1,31 @@
+ServerEvents.recipes((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/byg/shaped/';
+
+    const recipes = [
+        {
+            output: '5x byg:therium_lamp',
+            pattern: ['ABA', 'BAB', 'ABA'],
+            key: {
+                A: 'byg:therium_crystal_block',
+                B: '#forge:wires/lead'
+            },
+            id: 'byg:therium_lamp'
+        },
+        {
+            output: '5x byg:glowstone_lamp',
+            pattern: ['ABA', 'BAB', 'ABA'],
+            key: {
+                A: 'minecraft:glowstone',
+                B: '#forge:wires/lead'
+            },
+            id: 'byg:glowstone_lamp'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/create/mixing.js
+++ b/kubejs/server_scripts/expert/recipes/create/mixing.js
@@ -33,8 +33,11 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}iron_dust_from_sulfuric_acid`
         },
         {
-            results: [{ amount: 100, fluid: 'minecraft:water' }, { item: 'thermal:rubber' }],
-            ingredients: [{ amount: 900, fluidTag: 'forge:latex' }],
+            results: [
+                { amount: 100, fluid: 'minecraft:water' },
+                { item: 'thermal:rubber', count: 2 }
+            ],
+            ingredients: [{ amount: 1000, fluidTag: 'forge:latex' }],
             heatRequirement: 'heated',
             id: `${id_prefix}rubber`
         },

--- a/kubejs/server_scripts/expert/recipes/create/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/create/shaped.js
@@ -518,6 +518,16 @@ ServerEvents.recipes((event) => {
                 C: '#forge:plates/electrum'
             },
             id: `create:crafting/logistics/redstone_link`
+        },
+        {
+            output: 'create:display_link',
+            pattern: ['AB', 'CC'],
+            key: {
+                A: 'littlelogistics:transmitter_component',
+                B: 'immersiveengineering:light_bulb',
+                C: '#forge:treated_wood_slab'
+            },
+            id: `create:crafting/logistics/display_link`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/create/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/create/shaped.js
@@ -508,6 +508,16 @@ ServerEvents.recipes((event) => {
                 A: 'ars_nouveau:greater_experience_gem'
             },
             id: `create:crafting/materials/experience_block`
+        },
+        {
+            output: '2x create:redstone_link',
+            pattern: ['AB', 'CC'],
+            key: {
+                A: 'littlelogistics:transmitter_component',
+                B: 'littlelogistics:receiver_component',
+                C: '#forge:plates/electrum'
+            },
+            id: `create:crafting/logistics/redstone_link`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/create/shapeless.js
+++ b/kubejs/server_scripts/expert/recipes/create/shapeless.js
@@ -11,8 +11,14 @@ ServerEvents.recipes((event) => {
             id: `create:crafting/kinetics/sequenced_gearshift`
         },
         {
-            output: 'create:adjustable_chain_gearshift',
-            inputs: ['create:encased_chain_drive', 'immersiveengineering:component_electronic'],
+            output: '4x create:adjustable_chain_gearshift',
+            inputs: [
+                'create:encased_chain_drive',
+                'create:encased_chain_drive',
+                'create:encased_chain_drive',
+                'create:encased_chain_drive',
+                'immersiveengineering:component_electronic'
+            ],
             id: `create:crafting/kinetics/adjustable_chain_gearshift`
         },
         {

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -18,6 +18,7 @@ ServerEvents.recipes((event) => {
         { mod: 'compactmachines' },
         { mod: 'rftoolsbuilder' },
         { mod: 'rftoolsbase' },
+        { mod: 'shrink' },
 
         { output: /pneumaticcraft:.*_upgrade/ },
         { output: /powah:player_transmitter.*/ },

--- a/kubejs/server_scripts/expert/recipes/online_detector/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/online_detector/shaped.js
@@ -1,0 +1,25 @@
+ServerEvents.recipes((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/online_detector/shaped/';
+
+    const recipes = [
+        {
+            output: 'online_detector:advanced_online_detector',
+            pattern: ['ABA', 'CDC', 'AEA'],
+            key: {
+                A: '#forge:rods/lead',
+                B: 'quark:ender_watcher',
+                C: '#forge:plates/lumium',
+                D: 'online_detector:online_detector',
+                E: 'immersiveengineering:coil_mv'
+            },
+            id: 'online_detector:advanced_online_detector'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/pressure_chamber.js
@@ -506,7 +506,7 @@ ServerEvents.recipes((event) => {
         {
             results: [{ item: 'starbunclemania:star_battery', count: 1 }],
             inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_basic_large', count: 64 },
+                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_basic_large', count: 32 },
                 { item: 'hexerei:small_satchel' }
             ],
             pressure: 2.0,
@@ -515,7 +515,7 @@ ServerEvents.recipes((event) => {
         {
             results: [{ item: 'starbunclemania:star_battery', count: 1 }],
             inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_niotic', count: 16 },
+                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_niotic', count: 8 },
                 { item: 'hexerei:small_satchel' }
             ],
             pressure: 2.0,
@@ -524,24 +524,21 @@ ServerEvents.recipes((event) => {
         {
             results: [{ item: 'starbunclemania:star_battery', count: 1 }],
             inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_spirited', count: 4 },
+                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_spirited', count: 2 },
                 { item: 'hexerei:small_satchel' }
             ],
             pressure: 2.0,
             id: `${id_prefix}star_battery_spirited`
         },
         {
-            results: [{ item: 'starbunclemania:star_battery', count: 1 }],
+            results: [{ item: 'starbunclemania:star_battery', count: 2 }],
             inputs: [{ item: 'powah:capacitor_nitro' }, { item: 'hexerei:small_satchel' }],
             pressure: 2.0,
             id: `${id_prefix}star_battery_nitro`
         },
         {
             results: [{ item: 'starbunclemania:star_bucket', count: 1 }],
-            inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'thermal:fluid_cell_frame', count: 8 },
-                { item: 'hexerei:small_satchel' }
-            ],
+            inputs: [{ item: 'thermal:fluid_cell_frame' }, { item: 'hexerei:small_satchel' }],
             pressure: 2.0,
             id: `${id_prefix}star_bucket`
         },

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/pressure_chamber.js
@@ -506,7 +506,7 @@ ServerEvents.recipes((event) => {
         {
             results: [{ item: 'starbunclemania:star_battery', count: 1 }],
             inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_basic_large', count: 32 },
+                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_basic_large', count: 16 },
                 { item: 'hexerei:small_satchel' }
             ],
             pressure: 2.0,
@@ -515,7 +515,7 @@ ServerEvents.recipes((event) => {
         {
             results: [{ item: 'starbunclemania:star_battery', count: 1 }],
             inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_niotic', count: 8 },
+                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_niotic', count: 4 },
                 { item: 'hexerei:small_satchel' }
             ],
             pressure: 2.0,
@@ -524,14 +524,14 @@ ServerEvents.recipes((event) => {
         {
             results: [{ item: 'starbunclemania:star_battery', count: 1 }],
             inputs: [
-                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_spirited', count: 2 },
+                { type: 'pneumaticcraft:stacked_item', item: 'powah:capacitor_spirited', count: 1 },
                 { item: 'hexerei:small_satchel' }
             ],
             pressure: 2.0,
             id: `${id_prefix}star_battery_spirited`
         },
         {
-            results: [{ item: 'starbunclemania:star_battery', count: 2 }],
+            results: [{ item: 'starbunclemania:star_battery', count: 4 }],
             inputs: [{ item: 'powah:capacitor_nitro' }, { item: 'hexerei:small_satchel' }],
             pressure: 2.0,
             id: `${id_prefix}star_battery_nitro`

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
@@ -148,16 +148,16 @@ ServerEvents.recipes((event) => {
             item_output: { item: 'thermal:rubber' },
             fluid_input: { type: 'pneumaticcraft:fluid', amount: 500, tag: 'forge:latex' },
             exothermic: false,
-            temperature: { max_temp: 423, min_temp: 310 },
+            temperature: { max_temp: 423, min_temp: 373 },
             speed: 2.0,
             id: `${id_prefix}rubber`
         },
         {
-            fluid_output: { amount: 250, fluid: 'mekanism:sulfur_dioxide' },
-            fluid_input: { type: 'pneumaticcraft:fluid', amount: 250, fluid: 'minecraft:water' },
+            fluid_output: { amount: 1000, fluid: 'mekanism:sulfur_dioxide' },
+            fluid_input: { type: 'pneumaticcraft:fluid', amount: 1000, fluid: 'minecraft:water' },
             item_input: [{ tag: 'forge:essences/fire' }],
             exothermic: false,
-            temperature: { max_temp: 423, min_temp: 310 },
+            temperature: { max_temp: 423, min_temp: 373 },
             pressure: 2.0,
             speed: 2.0,
             id: `${id_prefix}sulfur_dioxide`
@@ -167,7 +167,7 @@ ServerEvents.recipes((event) => {
             item_input: [{ item: 'thermal:rubber' }],
             fluid_input: { type: 'pneumaticcraft:fluid', amount: 5, fluid: 'mekanism:sulfur_dioxide' },
             exothermic: false,
-            temperature: { max_temp: 423, min_temp: 310 },
+            temperature: { max_temp: 423, min_temp: 373 },
             speed: 2.0,
             id: `${id_prefix}cured_rubber`
         }

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
@@ -85,6 +85,7 @@ ServerEvents.recipes((event) => {
             item_input: [{ item: 'quark:blue_rune' }],
             pressure: 2.0,
             air_use_multiplier: 1.0,
+            temperature: { min_temp: 813 },
             speed: 2.0,
             id: `pneumaticcraft:thermo_plant/upgrade_matrix`
         },
@@ -135,13 +136,40 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}dielectric_paste`
         },
         {
-            fluid_output: { amount: 100, fluid: 'minecraft:water' },
-            item_output: { item: 'thermal:rubber' },
-            fluid_input: { type: 'pneumaticcraft:fluid', amount: 1000, tag: 'forge:latex' },
+            fluid_output: { amount: 50, fluid: 'industrialforegoing:latex' },
+            item_input: [{ item: 'minecraft:dandelion' }, { item: 'minecraft:vine' }],
             exothermic: false,
-            temperature: { max_temp: 320, min_temp: 310 },
+            pressure: 2.0,
+            speed: 2.0,
+            id: `${id_prefix}latex`
+        },
+        {
+            fluid_output: { amount: 50, fluid: 'minecraft:water' },
+            item_output: { item: 'thermal:rubber' },
+            fluid_input: { type: 'pneumaticcraft:fluid', amount: 500, tag: 'forge:latex' },
+            exothermic: false,
+            temperature: { max_temp: 423, min_temp: 310 },
             speed: 2.0,
             id: `${id_prefix}rubber`
+        },
+        {
+            fluid_output: { amount: 250, fluid: 'mekanism:sulfur_dioxide' },
+            fluid_input: { type: 'pneumaticcraft:fluid', amount: 250, fluid: 'minecraft:water' },
+            item_input: [{ tag: 'forge:essences/fire' }],
+            exothermic: false,
+            temperature: { max_temp: 423, min_temp: 310 },
+            pressure: 2.0,
+            speed: 2.0,
+            id: `${id_prefix}sulfur_dioxide`
+        },
+        {
+            item_output: { item: 'thermal:cured_rubber' },
+            item_input: [{ item: 'thermal:rubber' }],
+            fluid_input: { type: 'pneumaticcraft:fluid', amount: 5, fluid: 'mekanism:sulfur_dioxide' },
+            exothermic: false,
+            temperature: { max_temp: 423, min_temp: 310 },
+            speed: 2.0,
+            id: `${id_prefix}cured_rubber`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
@@ -133,6 +133,15 @@ ServerEvents.recipes((event) => {
             speed: 4.0,
             temperature: { min_temp: 813 },
             id: `${id_prefix}dielectric_paste`
+        },
+        {
+            fluid_output: { amount: 100, fluid: 'minecraft:water' },
+            item_output: { item: 'thermal:rubber' },
+            fluid_input: { type: 'pneumaticcraft:fluid', amount: 1000, tag: 'forge:latex' },
+            exothermic: false,
+            temperature: { max_temp: 320, min_temp: 310 },
+            speed: 2.0,
+            id: `${id_prefix}rubber`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/quark/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/quark/shaped.js
@@ -23,6 +23,15 @@ ServerEvents.recipes((event) => {
                 C: '#forge:ingots/bronze'
             },
             id: 'quark:tools/crafting/abacus'
+        },
+        {
+            output: '5x quark:framed_glass',
+            pattern: ['ABA', 'BAB', 'ABA'],
+            key: {
+                A: 'minecraft:glass',
+                B: '#forge:wires/lead'
+            },
+            id: 'quark:building/crafting/framed_glass'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/thermal/refinery.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/refinery.js
@@ -6,10 +6,10 @@ ServerEvents.recipes((event) => {
 
     const recipes = [
         {
-            ingredient: { fluid: 'industrialforegoing:latex', amount: 1000, count: 2.0 },
+            ingredient: { fluid: 'industrialforegoing:latex', amount: 1000 },
             result: [
                 { fluid: 'minecraft:water', amount: 100 },
-                { item: 'thermal:rubber', chance: 1.0 }
+                { item: 'thermal:rubber', chance: 2.0 }
             ],
             energy: 6000,
             id: `${id_prefix}rubber`

--- a/kubejs/server_scripts/expert/recipes/thermal/refinery.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/refinery.js
@@ -1,0 +1,23 @@
+ServerEvents.recipes((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/thermal/refinery/';
+
+    const recipes = [
+        {
+            ingredient: { fluid: 'industrialforegoing:latex', amount: 1000, count: 2.0 },
+            result: [
+                { fluid: 'minecraft:water', amount: 100 },
+                { item: 'thermal:rubber', chance: 1.0 }
+            ],
+            energy: 6000,
+            id: `${id_prefix}rubber`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'thermal:refinery';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/thermal/smelter.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/smelter.js
@@ -246,11 +246,7 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}depth_ingot`
         },
         {
-            ingredients: [
-                { item: 'thermal:rubber', count: 4 },
-                { tag: 'forge:essences/fire' },
-                { tag: 'forge:essences/water' }
-            ],
+            ingredients: [{ item: 'thermal:rubber', count: 4 }, { tag: 'forge:essences/fire' }],
             result: [{ item: `thermal:cured_rubber`, count: 4 }],
             energy: 1000,
             id: `${id_prefix}cured_rubber`

--- a/kubejs/server_scripts/normal/recipes/thermal/refinery.js
+++ b/kubejs/server_scripts/normal/recipes/thermal/refinery.js
@@ -1,0 +1,23 @@
+ServerEvents.recipes((event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:normal/thermal/refinery/';
+
+    const recipes = [
+        {
+            ingredient: { fluid: 'industrialforegoing:latex', amount: 900 },
+            result: [
+                { fluid: 'minecraft:water', amount: 100 },
+                { item: 'thermal:rubber', chance: 1.0 }
+            ],
+            energy: 6000,
+            id: `${id_prefix}rubber`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'thermal:refinery';
+        event.custom(recipe).id(recipe.id);
+    });
+});


### PR DESCRIPTION
- 1000mb of latex now makes 2 rubber
- TPP may be used to make rubber/cured rubber now. The entire process has changed somewhat as a result.
- Latex comes from the same sources, but TPP can press vines/dandelions for it as well
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/7c337e7a-a127-4970-88fa-c2f20599cd95)
- Latex is then cooked down to Rubber in the TPP (or other machines)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/861f42f7-bd28-4e6d-b871-95e4ee765735)
- The TPP can then cure it with sulfur dioxide. Create still uses fire essence.
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/81ea359f-e42a-457f-a04e-45c3f448549f)
- Sulfur Dioxide in turn can be made in the TPP now, making those Fire Essences go much further. 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/f1ddd489-4a33-4be4-a888-da58cdb2c18b)


This entire process in the TPP requires precise temperature controls, similar to biodiesel, so it won't be for everyone. But it offers an alternative to Create at least. 

- Adjustable Chain Drives are now cheaper
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/84df7d3f-4e42-4b71-8450-23a205319539)
- Star Buckets and Starbatteries are now significantly cheaper
- Shrink is now disabled in Expert.
- Ars Scalaes glyphs for shrink/growth are moved to tier 1
- Create Rolling now uses rods to make wires. Wires made from ingots in other machines now produce more to compensate. 
- Slag glass is now made from slag gravel to avoid issues with Create smelting.
- Framed Glass now uses lead wire instead of iron ingots
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/30c93666-7c12-4a23-a269-204c72dd8197)
- Therium and Glowstone lamps get a similar treatment
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/e187b7a9-f4e8-4c25-9fe4-d7792aebb193)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/83aedc11-72b5-4ce5-977d-7988ff0f87ee)
- Redstone links are easier to make
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/0f85f751-d5e5-4afc-b52e-b03bb6f9e916)
- Display links are similarly easier to make
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/1362b0a6-488f-4abc-96d1-ef96994dd5f4)
- Advanced Online Detectors moved earlier
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/16319ce7-563d-4851-9cbd-8964dc463624)
- Brimstone may now be crafted
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/9d3869e7-20e9-43ec-9e7e-edc6efd766c6)
- Brim Powder maybe obtained by crushing
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/547fc739-2dee-4c8d-b8bd-b472fd8d29af)
- Netherrack can be crafted in a Mixing Cauldron as well now, similar to the Create recipe
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/36fe28d7-230d-4279-b958-e8d5295c18e4)


