### PR TITLE
Disable Quark Piston Logic

### DIFF
--- a/config/configswapper/expert/config/quark-common.toml
+++ b/config/configswapper/expert/config/quark-common.toml
@@ -214,7 +214,7 @@
 	#Set to false to disable the popup message telling you that you can config quark in the q menu
 	"Enable Onboarding" = true
 	#Quark replaces the Piston logic to allow for its piston features to work. If you're having troubles, try turning this off.
-	"Use Piston Logic Replacement" = true
+	"Use Piston Logic Replacement" = false
 	"Disable Q Menu Effects" = false
 	#Set to true if you need to find the class name for a screen that's causing problems
 	"Print Screen Classnames" = false

--- a/config/configswapper/normal/config/quark-common.toml
+++ b/config/configswapper/normal/config/quark-common.toml
@@ -216,7 +216,7 @@
 	#Set to false to disable the popup message telling you that you can config quark in the q menu
 	"Enable Onboarding" = true
 	#Quark replaces the Piston logic to allow for its piston features to work. If you're having troubles, try turning this off.
-	"Use Piston Logic Replacement" = true
+	"Use Piston Logic Replacement" = false
 	"Disable Q Menu Effects" = false
 	#Set to true if you need to find the class name for a screen that's causing problems
 	"Print Screen Classnames" = false


### PR DESCRIPTION
Moving TEs has been disabled for a while already. Leaving this on with moving TEs disabled, however, appears to cause a crash in some situations.