### PR TITLE
Re-enable Quark Wraiths in Expert

### DIFF
--- a/config/configswapper/expert/config/quark-common.toml
+++ b/config/configswapper/expert/config/quark-common.toml
@@ -5,7 +5,7 @@
 	Foxhound = true
 	Forgotten = true
 	Shiba = true
-	Wraith = false
+	Wraith = true
 	Toretoise = false
 
 	[mobs.toretoise]


### PR DESCRIPTION
- Re-enable Quark Wraiths in Expert