### PR TITLE
Refresh Dark Mode Everywhere Default Config

### DIFF
--- a/defaultconfigs/darkmodeeverywhere-client.toml
+++ b/defaultconfigs/darkmodeeverywhere-client.toml
@@ -17,7 +17,7 @@ METHOD_SHADER_DUMP = false
 
 ["Main Menu Button"]
 	#Enabled
-	SHOW = true
+	SHOW = false
 	#Pixels away from the left of the GUI in the x axis
 	#Range: > 0
 	MAIN_X = 4

--- a/defaultconfigs/darkmodeeverywhere-client.toml
+++ b/defaultconfigs/darkmodeeverywhere-client.toml
@@ -7,7 +7,7 @@ METHOD_SHADER_BLACKLIST = ["mezz.jei.common.render.FluidTankRenderer:drawTexture
 #Use this feature to help find the render method strings of GUIs you would like to blacklist.
 METHOD_SHADER_DUMP = false
 
-["Button Position"]
+["Inventory Button"]
 	#Pixels away from the left of the GUI in the x axis
 	#Range: > 0
 	X = 2
@@ -15,13 +15,13 @@ METHOD_SHADER_DUMP = false
 	#Range: > 0
 	Y = 20
 
-	["Button Position"."Main Menu Button"]
-		#Enabled
-		SHOW = false
-		#Pixels away from the left of the GUI in the x axis
-		#Range: > 0
-		MAIN_X = 4
-		#Pixels away from the bottom of the GUI in the y axis
-		#Range: > 0
-		MAIN_Y = 40
+["Main Menu Button"]
+	#Enabled
+	SHOW = true
+	#Pixels away from the left of the GUI in the x axis
+	#Range: > 0
+	MAIN_X = 4
+	#Pixels away from the bottom of the GUI in the y axis
+	#Range: > 0
+	MAIN_Y = 40
 


### PR DESCRIPTION
Buuz changed the category names at some point so this config wasn't being applied which makes it sit half behind the EMI buttons.