### PR TITLE
Dripstone Updates

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,3 +1,15 @@
+### Enigmatica 9 v1.11.0
+
+### 🌟 Improvements
+
+-   Dummy recipes added to show how to make clay and lava from Dripstone. [\#595](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/595) ([MuteTiefling](https://github.com/MuteTiefling))
+
+### 🐛 Fixed Bugs
+
+-   Fix recipe conflict with crushing dripstone. [\#595](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/595) ([MuteTiefling](https://github.com/MuteTiefling))
+
+---
+
 ### Enigmatica 9 v1.10.2
 
 🚀 Forge-1.19.2-43.2.14 | [📜 Mod Updates](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/changelog_mods_1.10.2.md) | [📋 Modlist](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/modlist_1.10.2.md)

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -54,6 +54,7 @@ ServerEvents.recipes((event) => {
         { id: 'create:compat/byg/crushing/lignite_ore' },
         { id: 'create:crushing/blaze_rod' },
         { id: 'create:milling/sandstone' },
+        { id: 'create:milling/dripstone_block' },
         { id: 'create:milling/bone' },
         { id: 'create:milling/andesite' },
 

--- a/kubejs/server_scripts/base/recipes/lychee/dripstone_dripping.js
+++ b/kubejs/server_scripts/base/recipes/lychee/dripstone_dripping.js
@@ -1,0 +1,22 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/lychee/block_interacting/';
+
+    const recipes = [
+        {
+            source_block: 'minecraft:water',
+            target_block: 'minecraft:dirt',
+            post: [
+                {
+                    type: 'place',
+                    block: 'minecraft:mud'
+                }
+            ],
+            id: `${id_prefix}mud`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'lychee:dripstone_dripping';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
+++ b/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
@@ -19,6 +19,32 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}carved_pumpkin`
+        },
+        {
+            type: 'lychee:dripstone_dripping',
+            ghost: true,
+            source_block: 'minecraft:mud',
+            target_block: 'minecraft:air',
+            post: [
+                {
+                    type: 'place',
+                    block: { blocks: ['minecraft:clay'] }
+                }
+            ],
+            id: `${id_prefix}clay`
+        },
+        {
+            type: 'lychee:dripstone_dripping',
+            ghost: true,
+            source_block: 'minecraft:lava',
+            target_block: 'minecraft:cauldron',
+            post: [
+                {
+                    type: 'place',
+                    block: { blocks: ['minecraft:lava'] }
+                }
+            ],
+            id: `${id_prefix}lava`
         }
     ];
 


### PR DESCRIPTION
Lychee Dummy recipes added to show vanilla mechanics for obtaining Clay and Lava from Dripstone
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/8d9ada48-9ded-43b8-94e2-36e1fc1e106f)

New recipe added to convert dirt to mud via dripstone

Dripstone > Clay crushing recipe removed due to conflict. Plenty of clay recipes remain.  https://github.com/EnigmaticaModpacks/Enigmatica9/issues/593

