### PR TITLE
Attempting to fix false starts in overworld

### DIFF
--- a/kubejs/server_scripts/expert/player_events/starting_errors.js
+++ b/kubejs/server_scripts/expert/player_events/starting_errors.js
@@ -1,5 +1,5 @@
-//priority: 900
-
+//priority: 1000
+// This must run before starting_items.js, so the initial starting_items tag isn't present, only existing ones
 PlayerEvents.loggedIn((event) => {
     if (global.isExpertMode == false) {
         return;

--- a/kubejs/server_scripts/expert/player_events/starting_errors.js
+++ b/kubejs/server_scripts/expert/player_events/starting_errors.js
@@ -3,8 +3,8 @@ PlayerEvents.loggedIn((event) => {
         return;
     }
 
-    const { player, level, server } = event;
     const twilight_portal = Java.loadClass('twilightforest.block.TFPortalBlock');
+    const { player, level, server } = event;
 
     if (player.stages.has('starting_errors') && !player.stages.has('starting_errors_corrected')) {
         // Second load detected, Twilight should be available so send them there.
@@ -17,9 +17,9 @@ PlayerEvents.loggedIn((event) => {
         player.stages.add('starting_errors');
 
         if (String(level.getDimension()) == 'minecraft:overworld') {
-            server.runCommandSilent(
-                `/kick ${player.getUsername()} An issue was detected with your world start! Please join the world again to correct it.`
-            );
+            let username = player.getUsername();
+            let command = `/kick ${username} An issue was detected with your world start! Please join the world again to correct it.`;
+            server.runCommandSilent(command);
         }
     }
 });

--- a/kubejs/server_scripts/expert/player_events/starting_errors.js
+++ b/kubejs/server_scripts/expert/player_events/starting_errors.js
@@ -1,3 +1,5 @@
+//priority: 900
+
 PlayerEvents.loggedIn((event) => {
     if (global.isExpertMode == false) {
         return;
@@ -12,13 +14,16 @@ PlayerEvents.loggedIn((event) => {
         player.stages.add('starting_errors_corrected');
     }
 
-    if (!player.stages.has('starting_errors')) {
+    if (!player.stages.has('starting_items') && !player.stages.has('starting_errors')) {
         // First load detected, kick the player with a message to rejoin.
         player.stages.add('starting_errors');
 
         if (String(level.getDimension()) == 'minecraft:overworld') {
             let username = player.getUsername();
             let command = `/kick ${username} An issue was detected with your world start! Please join the world again to correct it.`;
+            console.log(
+                'Enigmatica: Issues were detected with the world start. Rejoining the world is required to fix it.'
+            );
             server.runCommandSilent(command);
         }
     }

--- a/kubejs/server_scripts/expert/player_events/starting_errors.js
+++ b/kubejs/server_scripts/expert/player_events/starting_errors.js
@@ -1,0 +1,25 @@
+PlayerEvents.loggedIn((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const { player, level, server } = event;
+    const twilight_portal = Java.loadClass('twilightforest.block.TFPortalBlock');
+
+    if (player.stages.has('starting_errors') && !player.stages.has('starting_errors_corrected')) {
+        // Second load detected, Twilight should be available so send them there.
+        twilight_portal.attemptSendEntity(player, true, false);
+        player.stages.add('starting_errors_corrected');
+    }
+
+    if (!player.stages.has('starting_errors')) {
+        // First load detected, kick the player with a message to rejoin.
+        player.stages.add('starting_errors');
+
+        if (String(level.getDimension()) == 'minecraft:overworld') {
+            server.runCommandSilent(
+                `/kick ${player.getUsername()} An issue was detected with your world start! Please join the world again to correct it.`
+            );
+        }
+    }
+});

--- a/kubejs/server_scripts/expert/player_events/starting_items.js
+++ b/kubejs/server_scripts/expert/player_events/starting_items.js
@@ -1,10 +1,13 @@
+//priority: 1000
+
 PlayerEvents.loggedIn((event) => {
     if (global.isExpertMode == false) {
         return;
     }
+    const { player } = event;
 
-    if (!event.player.stages.has('starting_items')) {
-        event.player.stages.add('starting_items');
+    if (!player.stages.has('starting_items')) {
+        player.stages.add('starting_items');
 
         let starting_items = [
             Item.of('minecraft:bow', {
@@ -27,10 +30,10 @@ PlayerEvents.loggedIn((event) => {
         ];
 
         starting_items.forEach((item) => {
-            event.player.give(item);
+            player.give(item);
         });
 
-        event.player.setHeadArmorItem(
+        player.setHeadArmorItem(
             Item.of('minecraft:leather_helmet', {
                 Damage: 0,
                 display: { Name: '{"text":"Sturdy Leather Cap","color":"dark_green"}', color: 7441479 },
@@ -39,7 +42,7 @@ PlayerEvents.loggedIn((event) => {
             }).enchant('minecraft:unbreaking', 1)
         );
 
-        event.player.setChestArmorItem(
+        player.setChestArmorItem(
             Item.of('minecraft:leather_chestplate', {
                 Damage: 0,
                 display: { Name: '{"text":"Sturdy Leather Tunic","color":"dark_green"}', color: 7441479 },
@@ -48,7 +51,7 @@ PlayerEvents.loggedIn((event) => {
             }).enchant('minecraft:unbreaking', 1)
         );
 
-        event.player.setLegsArmorItem(
+        player.setLegsArmorItem(
             Item.of('minecraft:leather_leggings', {
                 Damage: 0,
                 display: { Name: '{"text":"Sturdy Leather Pants","color":"dark_green"}', color: 7441479 },
@@ -57,7 +60,7 @@ PlayerEvents.loggedIn((event) => {
             }).enchant('minecraft:unbreaking', 1)
         );
 
-        event.player.setFeetArmorItem(
+        player.setFeetArmorItem(
             Item.of('minecraft:leather_boots', {
                 Damage: 0,
                 display: { Name: '{"text":"Sturdy Leather Boots","color":"dark_green"}', color: 7441479 },

--- a/kubejs/server_scripts/expert/player_events/starting_items.js
+++ b/kubejs/server_scripts/expert/player_events/starting_items.js
@@ -1,4 +1,4 @@
-//priority: 1000
+//priority: 900
 
 PlayerEvents.loggedIn((event) => {
     if (global.isExpertMode == false) {


### PR DESCRIPTION
Due to https://github.com/EnigmaticaModpacks/Enigmatica9/issues/598 some players are starting in the Overworld. 

When this happens, the Twilight Forest is not even registered as a dimension, meaning nothing can be done to 'fix' them on first load. Therefore, we kick them with a message explaining the situation. 

Upon second load, they're teleported safely to the twilight using `TFPortalBlock`. 

Currently, however, once this is complete, the player cannot die... I suspect an issue with the worldspawn location but attempts to fix that via commands have so far failed. 