### PR TITLE
Tree improvements

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -11,6 +11,8 @@
 -   Frogs may now spawn in Twilight Forest Swamps. [\#606](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/606) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Several Creatures and Beasts mobs now have higher chances to spawn in the Twilight Forest. [\#606](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/606) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] Add mention in the first quest that Twilight Forest progression is disabled. [\#606](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/606) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Hide misleading info about quark ancient sapling. [\#608](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/608) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Increase drop rate of Hexerei saplings. [\#608](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/608) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/config/configswapper/expert/config/quark-common.toml
+++ b/config/configswapper/expert/config/quark-common.toml
@@ -229,7 +229,7 @@
 	#Set to false to disable Quark's item info when viweing recipe/uses for an item in JEI
 	"Enable Jei Item Info" = true
 	#For JEI info purposes, add any items here to specifically disable their JEI info from Quark. Note that Quark already only shows info that's relevant to which features are enabled
-	"Suppressed Info" = []
+	"Suppressed Info" = ["quark:ancient_sapling"]
 
 [automation]
 	Chute = false

--- a/kubejs/server_scripts/base/loot_tables/blocks/hexerei/mahogany_leaves.js
+++ b/kubejs/server_scripts/base/loot_tables/blocks/hexerei/mahogany_leaves.js
@@ -1,0 +1,85 @@
+ServerEvents.blockLootTables((event) => {
+    event.addBlock(`quark:ancient_leaves`, (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.bonusRolls = 0.0;
+            pool.addEntry({
+                type: 'minecraft:alternatives',
+                children: [
+                    {
+                        type: 'minecraft:item',
+                        conditions: [
+                            {
+                                condition: 'minecraft:alternative',
+                                terms: [
+                                    { condition: 'forge:can_tool_perform_action', action: 'shears_dig' },
+                                    {
+                                        condition: 'minecraft:match_tool',
+                                        predicate: {
+                                            enchantments: [{ enchantment: 'minecraft:silk_touch', levels: { min: 1 } }]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        name: 'hexerei:mahogany_leaves'
+                    },
+                    {
+                        type: 'minecraft:item',
+                        conditions: [
+                            { condition: 'minecraft:survives_explosion' },
+                            {
+                                condition: 'minecraft:table_bonus',
+                                enchantment: 'minecraft:fortune',
+                                chances: [0.05, 0.0625, 0.083333336, 0.1]
+                            }
+                        ],
+                        name: 'hexerei:mahogany_sapling'
+                    }
+                ]
+            });
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.bonusRolls = 0.0;
+            pool.addEntry({
+                type: 'minecraft:item',
+                conditions: [
+                    {
+                        condition: 'minecraft:table_bonus',
+                        enchantment: 'minecraft:fortune',
+                        chances: [0.02, 0.022222223, 0.025, 0.033333335, 0.1]
+                    }
+                ],
+                functions: [
+                    {
+                        function: 'minecraft:set_count',
+                        count: { type: 'minecraft:uniform', min: 1.0, max: 2.0 },
+                        add: false
+                    },
+                    {
+                        function: 'minecraft:explosion_decay'
+                    }
+                ],
+                name: 'minecraft:stick'
+            });
+            pool.addCondition({
+                condition: 'minecraft:inverted',
+                term: {
+                    condition: 'minecraft:alternative',
+                    terms: [
+                        {
+                            condition: 'forge:can_tool_perform_action',
+                            action: 'shears_dig'
+                        },
+                        {
+                            condition: 'minecraft:match_tool',
+                            predicate: { enchantments: [{ enchantment: 'minecraft:silk_touch', levels: { min: 1 } }] }
+                        }
+                    ]
+                }
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/base/loot_tables/blocks/hexerei/willow_leaves.js
+++ b/kubejs/server_scripts/base/loot_tables/blocks/hexerei/willow_leaves.js
@@ -1,0 +1,85 @@
+ServerEvents.blockLootTables((event) => {
+    event.addBlock(`quark:ancient_leaves`, (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.bonusRolls = 0.0;
+            pool.addEntry({
+                type: 'minecraft:alternatives',
+                children: [
+                    {
+                        type: 'minecraft:item',
+                        conditions: [
+                            {
+                                condition: 'minecraft:alternative',
+                                terms: [
+                                    { condition: 'forge:can_tool_perform_action', action: 'shears_dig' },
+                                    {
+                                        condition: 'minecraft:match_tool',
+                                        predicate: {
+                                            enchantments: [{ enchantment: 'minecraft:silk_touch', levels: { min: 1 } }]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        name: 'hexerei:willow_leaves'
+                    },
+                    {
+                        type: 'minecraft:item',
+                        conditions: [
+                            { condition: 'minecraft:survives_explosion' },
+                            {
+                                condition: 'minecraft:table_bonus',
+                                enchantment: 'minecraft:fortune',
+                                chances: [0.05, 0.0625, 0.083333336, 0.1]
+                            }
+                        ],
+                        name: 'hexerei:willow_sapling'
+                    }
+                ]
+            });
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.bonusRolls = 0.0;
+            pool.addEntry({
+                type: 'minecraft:item',
+                conditions: [
+                    {
+                        condition: 'minecraft:table_bonus',
+                        enchantment: 'minecraft:fortune',
+                        chances: [0.02, 0.022222223, 0.025, 0.033333335, 0.1]
+                    }
+                ],
+                functions: [
+                    {
+                        function: 'minecraft:set_count',
+                        count: { type: 'minecraft:uniform', min: 1.0, max: 2.0 },
+                        add: false
+                    },
+                    {
+                        function: 'minecraft:explosion_decay'
+                    }
+                ],
+                name: 'minecraft:stick'
+            });
+            pool.addCondition({
+                condition: 'minecraft:inverted',
+                term: {
+                    condition: 'minecraft:alternative',
+                    terms: [
+                        {
+                            condition: 'forge:can_tool_perform_action',
+                            action: 'shears_dig'
+                        },
+                        {
+                            condition: 'minecraft:match_tool',
+                            predicate: { enchantments: [{ enchantment: 'minecraft:silk_touch', levels: { min: 1 } }] }
+                        }
+                    ]
+                }
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/base/loot_tables/blocks/hexerei/witch_hazel_leaves.js
+++ b/kubejs/server_scripts/base/loot_tables/blocks/hexerei/witch_hazel_leaves.js
@@ -1,0 +1,85 @@
+ServerEvents.blockLootTables((event) => {
+    event.addBlock(`quark:ancient_leaves`, (table) => {
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.bonusRolls = 0.0;
+            pool.addEntry({
+                type: 'minecraft:alternatives',
+                children: [
+                    {
+                        type: 'minecraft:item',
+                        conditions: [
+                            {
+                                condition: 'minecraft:alternative',
+                                terms: [
+                                    { condition: 'forge:can_tool_perform_action', action: 'shears_dig' },
+                                    {
+                                        condition: 'minecraft:match_tool',
+                                        predicate: {
+                                            enchantments: [{ enchantment: 'minecraft:silk_touch', levels: { min: 1 } }]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        name: 'hexerei:witch_hazel_leaves'
+                    },
+                    {
+                        type: 'minecraft:item',
+                        conditions: [
+                            { condition: 'minecraft:survives_explosion' },
+                            {
+                                condition: 'minecraft:table_bonus',
+                                enchantment: 'minecraft:fortune',
+                                chances: [0.05, 0.0625, 0.083333336, 0.1]
+                            }
+                        ],
+                        name: 'hexerei:witch_hazel_sapling'
+                    }
+                ]
+            });
+        });
+
+        table.addPool((pool) => {
+            pool.rolls = 1.0;
+            pool.bonusRolls = 0.0;
+            pool.addEntry({
+                type: 'minecraft:item',
+                conditions: [
+                    {
+                        condition: 'minecraft:table_bonus',
+                        enchantment: 'minecraft:fortune',
+                        chances: [0.02, 0.022222223, 0.025, 0.033333335, 0.1]
+                    }
+                ],
+                functions: [
+                    {
+                        function: 'minecraft:set_count',
+                        count: { type: 'minecraft:uniform', min: 1.0, max: 2.0 },
+                        add: false
+                    },
+                    {
+                        function: 'minecraft:explosion_decay'
+                    }
+                ],
+                name: 'minecraft:stick'
+            });
+            pool.addCondition({
+                condition: 'minecraft:inverted',
+                term: {
+                    condition: 'minecraft:alternative',
+                    terms: [
+                        {
+                            condition: 'forge:can_tool_perform_action',
+                            action: 'shears_dig'
+                        },
+                        {
+                            condition: 'minecraft:match_tool',
+                            predicate: { enchantments: [{ enchantment: 'minecraft:silk_touch', levels: { min: 1 } }] }
+                        }
+                    ]
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
hide default misleading info about quark ancient tree sapling
increase drop rate of Mahogany saplings to avoid issues early game with not getting enough saplings back from a tree