### PR TITLE
More SPS changes

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Mana Boost may now be upgraded up to VII in the Mana Enchanter to match Mana Regen. [\#621](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/621) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] End Game process for making Dragon parts has changed. [\#621](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/621) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] SPS sculk requirements reduced. [\#622](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/622) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] SPS ports and supercharged coils no longer need supreme machine frames as they're included in the SPS frame recipe. [\#623](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/623) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
@@ -640,7 +640,7 @@ ServerEvents.recipes((event) => {
                 'powah:capacitor_nitro',
                 'quark:rainbow_rune',
                 'powah:capacitor_nitro',
-                '#industrialforegoing:machine_frame/supreme',
+                'ars_elemental:acceleration_prism_lens',
                 'powah:capacitor_nitro',
                 'quark:rainbow_rune',
                 'powah:capacitor_nitro'

--- a/kubejs/server_scripts/expert/recipes/occultism/ritual.js
+++ b/kubejs/server_scripts/expert/recipes/occultism/ritual.js
@@ -1352,7 +1352,7 @@ ServerEvents.recipes((event) => {
         },
         {
             output: Item.of('3x mekanism:sps_port'),
-            activation_item: '#industrialforegoing:machine_frame/supreme',
+            activation_item: 'ae2:spatial_io_port',
             inputs: [
                 'ae2:spatial_anchor',
                 'ae2:spatial_anchor',


### PR DESCRIPTION
SPS Ports and Supercharged Coils no longer need supreme machine frames as they're included in the Frames themselves. 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/c298e04e-43ff-4115-938e-0fe0cb8f61c1)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/cc03c034-fe5c-4877-8342-fe0427224ee4)
