### PR TITLE
Construction wand quest

### DIFF
--- a/config/ftbquests/quests/chapters/building.snbt
+++ b/config/ftbquests/quests/chapters/building.snbt
@@ -538,14 +538,6 @@
 				""
 				"Ctrl Shift the wand in the air to access a menu with advanced options, or Ctrl Scroll Wheel to quickly toggle between building modes. "
 			]
-			icon: {
-				Count: 1b
-				id: "constructionwand:stone_wand"
-				tag: {
-					Damage: 0
-					wand_options: { }
-				}
-			}
 			id: "26B88D08862EA1AE"
 			rewards: [{
 				count: 16
@@ -559,15 +551,31 @@
 				id: "131EB02FBDE8DC98"
 				item: {
 					Count: 1b
-					id: "constructionwand:diamond_wand"
+					id: "itemfilters:or"
 					tag: {
-						Damage: 0
-						wand_options: { }
+						items: [
+							{
+								Count: 1b
+								id: "constructionwand:diamond_wand"
+								tag: {
+									Damage: 0
+									wand_options: { }
+								}
+							}
+							{
+								Count: 1b
+								id: "constructionwand:infinity_wand"
+								tag: {
+									wand_options: { }
+								}
+							}
+						]
 					}
 				}
+				title: "Construction Wands"
 				type: "item"
 			}]
-			title: "Construction Wand"
+			title: "Construction Wands"
 			x: -0.5d
 			y: 4.0d
 		}


### PR DESCRIPTION
Allow the construction wand quest to be completed using either a diamond wand, or an infinity wand.
Changed the quest name to be plural to reflect this change.
Changed the icon such that instead of a stone wand (which I think is disabled), it is "air" such that the icon alternates between the diamond wand or infinity wand.

Just a minor but would be appreciated QOL thing. The Infinity Wand recipe is not that hard and can be made in stage 1. It is pretty much better than the diamond one in every way (other than when you accidently click and plop down way too much dirt on the ground), and the recipe does not involve the diamond wand so you cannot even complete the construction wand quest as part of the recipe. 