### PR TITLE
General Improvements

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -16,6 +16,9 @@
 -   [Expert] Quark's Ancient Sapling and related wood items have been renamed to Resplendent Elder Saplings to avoid confusion with Nature's Aura Ancient Saplings. [\#653](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/653) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] AE2 Annihilation and Formation cores now use Wyrms to craft. Sorry Bailey! [\#660](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/660) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] Threads now use 200 mb of potion instead of 2000. [\#660](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/660) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Infinity Tools are now crafted directly at Artifact tier. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Cave Trolls have been buffed with regeneration and knockback effects. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Minotaurs and Minoshrooms can now snare you, making them very dangerous in packs. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 
@@ -27,6 +30,7 @@
 -   Fixed missing Compressed Stone Ladder recipe [\#644](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/644) ([MuteTiefling](https://github.com/MuteTiefling))
 -   And even more quest typos and clarifications [\#644](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/644) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] Remove Tablet of Summon Wilden from all loot tables [\#660](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/660) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Fixed some bugged quest loot in the Nature's Aura chapter. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed typos in quests [\#632](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/632) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed typos in quests [\#639](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/639) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed typos in quests [\#652](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/652) ([MuteTiefling](https://github.com/MuteTiefling))

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   [Expert] Infinity Tools are now crafted directly at Artifact tier. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Cave Trolls have been buffed with regeneration and knockback effects. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Minotaurs and Minoshrooms can now snare you, making them very dangerous in packs. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Death Tome quest now has an associated advancement to assist in triggering it from the ritual. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -1109,12 +1109,6 @@
 			shape: "hexagon"
 			tasks: [
 				{
-					entity: "twilightforest:death_tome"
-					id: "0DBE4EB438DD3212"
-					type: "kill"
-					value: 5L
-				}
-				{
 					id: "3D0287DCD0BE94E2"
 					item: {
 						Count: 1b
@@ -1125,6 +1119,12 @@
 					}
 					optional_task: true
 					type: "item"
+				}
+				{
+					advancement: "occultism:occultism/undefined"
+					criterion: ""
+					id: "1397737665563059"
+					type: "advancement"
 				}
 			]
 			title: "Summon Death Tome"

--- a/config/ftbquests/quests/chapters/industrial_foregoing_expert.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing_expert.snbt
@@ -159,7 +159,7 @@
 				""
 				"Sneak Right-Click to set its options. "
 				""
-				"Right-Click on a tank of Biofuel to fill it. "
+				"Right-Click on a tank of Abyssaline to fill it. "
 			]
 			hide_dependency_lines: true
 			id: "41E4A38DBA6DE6A7"
@@ -172,19 +172,19 @@
 				type: "command"
 			}]
 			tasks: [{
-				id: "03AF60226A59F3DE"
+				id: "0FA22DD447DAE6C6"
 				item: {
 					Count: 1b
 					id: "industrialforegoing:infinity_drill"
 					tag: {
-						CanCharge: 1
-						Energy: 0
+						CanCharge: 1b
+						Energy: 9223372036854775807L
 						Fluid: {
 							Amount: 0
 							FluidName: "biofuel"
 						}
-						Selected: "POOR"
-						Special: 0
+						Selected: "ARTIFACT"
+						Special: 0b
 					}
 				}
 				type: "item"
@@ -230,7 +230,7 @@
 				""
 				"Sneak Right-Click to set its options. "
 				""
-				"Right-Click on a tank of Biofuel to fill it. "
+				"Right-Click on a tank of Abyssaline to fill it. "
 			]
 			hide_dependency_lines: true
 			id: "63A495A27778E61B"
@@ -243,21 +243,21 @@
 				type: "command"
 			}]
 			tasks: [{
-				id: "4A927A428D655966"
+				id: "7BF1222DDFC15890"
 				item: {
 					Count: 1b
 					id: "industrialforegoing:infinity_trident"
 					tag: {
 						CanCharge: 1b
 						Channeling: 0b
-						Energy: 0L
+						Energy: 9223372036854775807L
 						Fluid: {
 							Amount: 0
 							FluidName: "biofuel"
 						}
 						Loyalty: 0
 						Riptide: 0
-						Selected: "POOR"
+						Selected: "ARTIFACT"
 						Special: 0b
 					}
 				}
@@ -269,11 +269,11 @@
 		{
 			dependencies: ["3A4F484FD23B29BA"]
 			description: [
-				"A heavy melee weapon that smashes anything in the area. It comes with a built in Beheading enchantment that may be toggled on and off. "
+				"The perfect tool for clearing vast tracts of land of any form of tree. This saw operates unlike most tools in that it works its way down from the top of the tree."
 				""
 				"Sneak Right-Click to set its options. "
 				""
-				"Right-Click on a tank of Biofuel to fill it. "
+				"Right-Click on a tank of Abyssaline to fill it."
 			]
 			hide_dependency_lines: true
 			id: "255410094C4D7875"
@@ -287,19 +287,19 @@
 			}]
 			subtitle: "I'm Still Worthy!"
 			tasks: [{
-				id: "5A75E1A302F15DE1"
+				id: "4B57CA7C3F20BDE7"
 				item: {
 					Count: 1b
 					id: "industrialforegoing:infinity_hammer"
 					tag: {
 						Beheading: 0
 						CanCharge: 1b
-						Energy: 0L
+						Energy: 9223372036854775807L
 						Fluid: {
 							Amount: 0
 							FluidName: "biofuel"
 						}
-						Selected: "POOR"
+						Selected: "ARTIFACT"
 						Special: 0b
 					}
 				}
@@ -609,6 +609,102 @@
 			title: "Laser Drilling"
 			x: 7.0d
 			y: -6.0d
+		}
+		{
+			dependencies: ["3A4F484FD23B29BA"]
+			description: [
+				"The ultimate weapon, capable of destroying anything and anyone in a vast area. "
+				""
+				"You’ve been warned. "
+				""
+				"Sneak Right-Click to set its options. "
+				""
+				"Right-Click on a tank of Abyssaline to fill it."
+				""
+				"================================="
+				""
+				"To detonate: "
+				""
+				"  1. Place it somewhere far from "
+				"     anything important."
+				""
+				"  2. Right-Click it to arm it. The casing "
+				"     will close. "
+				""
+				"  3. Light it with a Flint and Steel."
+				""
+				"  4. Run."
+			]
+			hide_dependency_lines: true
+			id: "18BB0AEB0616ED46"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
+				icon: "kubejs:epic_lootbox"
+				id: "770DD847637FC248"
+				player_command: false
+				title: "Epic Industrial Foregoing Loot Box"
+				type: "command"
+			}]
+			tasks: [{
+				id: "0B8F6AF714283187"
+				item: {
+					Count: 1b
+					id: "industrialforegoing:infinity_nuke"
+					tag: {
+						CanCharge: 1b
+						Energy: 9223372036854775807L
+						Fluid: {
+							Amount: 0
+							FluidName: "biofuel"
+						}
+						Selected: "ARTIFACT"
+						Special: 0b
+					}
+				}
+				type: "item"
+			}]
+			x: 6.0d
+			y: -2.0d
+		}
+		{
+			dependencies: ["3A4F484FD23B29BA"]
+			description: [
+				"The perfect tool for clearing vast tracts of land of any form of tree. This saw operates unlike most tools in that it breaks blocks from the top of the tree down towards wherever it is being used. It clears wood and leaves in an area centered on where it is used, whether those trees are connected to the one being sawed or not."
+				""
+				"Sneak Right-Click to set its options. "
+				""
+				"Right-Click on a tank of Abyssaline to fill it."
+			]
+			hide_dependency_lines: true
+			id: "6D2D4406B69A437B"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
+				icon: "kubejs:epic_lootbox"
+				id: "5C632F4FB5098CA3"
+				player_command: false
+				title: "Epic Industrial Foregoing Loot Box"
+				type: "command"
+			}]
+			tasks: [{
+				id: "126DC872A6482962"
+				item: {
+					Count: 1b
+					id: "industrialforegoing:infinity_saw"
+					tag: {
+						CanCharge: 1b
+						Energy: 9223372036854775807L
+						Fluid: {
+							Amount: 0
+							FluidName: "biofuel"
+						}
+						Selected: "ARTIFACT"
+						Special: 0b
+					}
+				}
+				type: "item"
+			}]
+			x: 7.0d
+			y: -2.0d
 		}
 	]
 	title: "Industrial Foregoing"

--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -1152,11 +1152,11 @@
 			hide_dependency_lines: true
 			id: "4A5FA8B49626B99C"
 			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/quest_blacksmiths_delight"
-				icon: "kubejs:blacksmiths_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
+				icon: "kubejs:rare_lootbox"
 				id: "3DBA5D25A0607A73"
 				player_command: false
-				title: "Blacksmith's Delight"
+				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
 			tasks: [{

--- a/config/ftbquests/quests/chapters/natures_aura_expert.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura_expert.snbt
@@ -1108,11 +1108,11 @@
 			hide_dependency_lines: true
 			id: "712E3B21060DB19C"
 			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/quest_blacksmiths_delight"
-				icon: "kubejs:blacksmiths_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
+				icon: "kubejs:rare_lootbox"
 				id: "28CC27FC10BC0B9B"
 				player_command: false
-				title: "Blacksmith's Delight"
+				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
 			tasks: [{

--- a/config/ftbquests/quests/chapters/tools_expert.snbt
+++ b/config/ftbquests/quests/chapters/tools_expert.snbt
@@ -875,15 +875,30 @@
 						items: [
 							{
 								Count: 1b
-								id: "industrialforegoing:infinity_saw"
+								id: "industrialforegoing:infinity_nuke"
 								tag: {
 									CanCharge: 1b
-									Energy: 0L
+									Energy: 9223372036854775807L
 									Fluid: {
 										Amount: 0
 										FluidName: "biofuel"
 									}
-									Selected: "POOR"
+									Selected: "ARTIFACT"
+									Special: 0b
+								}
+							}
+							{
+								Count: 1b
+								id: "industrialforegoing:infinity_hammer"
+								tag: {
+									Beheading: 0
+									CanCharge: 1b
+									Energy: 9223372036854775807L
+									Fluid: {
+										Amount: 0
+										FluidName: "biofuel"
+									}
+									Selected: "ARTIFACT"
 									Special: 0b
 								}
 							}
@@ -892,12 +907,43 @@
 								id: "industrialforegoing:infinity_drill"
 								tag: {
 									CanCharge: 1b
-									Energy: 0L
+									Energy: 9223372036854775807L
 									Fluid: {
 										Amount: 0
 										FluidName: "biofuel"
 									}
-									Selected: "POOR"
+									Selected: "ARTIFACT"
+									Special: 0b
+								}
+							}
+							{
+								Count: 1b
+								id: "industrialforegoing:infinity_trident"
+								tag: {
+									CanCharge: 1b
+									Channeling: 0b
+									Energy: 9223372036854775807L
+									Fluid: {
+										Amount: 0
+										FluidName: "biofuel"
+									}
+									Loyalty: 0
+									Riptide: 0
+									Selected: "ARTIFACT"
+									Special: 0b
+								}
+							}
+							{
+								Count: 1b
+								id: "industrialforegoing:infinity_saw"
+								tag: {
+									CanCharge: 1b
+									Energy: 9223372036854775807L
+									Fluid: {
+										Amount: 0
+										FluidName: "biofuel"
+									}
+									Selected: "ARTIFACT"
 									Special: 0b
 								}
 							}

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -656,6 +656,8 @@
     "ritual.enigmatica.occultism/ritual/swarm_gate_large.interrupted": "Large Mite Swarm Gateway Interrupted",
     "ritual.enigmatica.occultism/ritual/swarm_gate_large.conditions": "Not all requirements for this ritual are met.",
 
+    "advancements.occultism.death_tome_gate_small.title": "Summon Death Tomes",
+    "advancements.occultism.death_tome_gate_small.description": "Summon Death Tomes",
     "gateways.death_tome_gate": "Death Tome Gate",
     "gateways.death_tome_gate_small": "Small Death Tome Gate",
     "gateways.death_tome_gate_large": "Large Death Tome Gate",

--- a/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/cave_troll.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/cave_troll.js
@@ -1,0 +1,30 @@
+ServerEvents.highPriorityData((event) => {
+    const id_prefix = 'apotheosis:boss_gear/miniboss/';
+    const recipes = [
+        {
+            name: 'troll',
+            weight: 100,
+            quality: 2.5,
+            mainhands: [],
+            offhands: [],
+            helmets: [],
+            chestplates: [
+                {
+                    stack: {
+                        item: 'minecraft:leather_chestplate',
+                        nbt: Object.assign(reactive.ground_slam, enchant_glint.blank, enchantments.reactive_2)
+                    },
+                    weight: 100,
+                    drop_chance: 0.0
+                }
+            ],
+            leggings: [],
+            boots: [],
+            tags: ['miniboss/troll']
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.addJson(`${id_prefix}${recipe.name}.json`, recipe);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/minoshroom.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/minoshroom.js
@@ -1,0 +1,36 @@
+ServerEvents.highPriorityData((event) => {
+    const id_prefix = 'apotheosis:boss_gear/miniboss/';
+    const recipes = [
+        {
+            name: 'minoshroom',
+            weight: 100,
+            quality: 2.5,
+            mainhands: [
+                {
+                    stack: { item: 'twilightforest:diamond_minotaur_axe', nbt: default_nbt },
+                    weight: 100,
+                    drop_chance: 0.085
+                }
+            ],
+            offhands: [],
+            helmets: [],
+            chestplates: [],
+            leggings: [],
+            boots: [
+                {
+                    stack: {
+                        item: 'minecraft:leather_boots',
+                        nbt: Object.assign(reactive.earth_snare, enchant_glint.blank, enchantments.reactive_4)
+                    },
+                    weight: 100,
+                    drop_chance: 0.0
+                }
+            ],
+            tags: ['miniboss/minoshroom']
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.addJson(`${id_prefix}${recipe.name}.json`, recipe);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/minotaur.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/miniboss_gear/minotaur.js
@@ -1,0 +1,36 @@
+ServerEvents.highPriorityData((event) => {
+    const id_prefix = 'apotheosis:boss_gear/miniboss/';
+    const recipes = [
+        {
+            name: 'minotaur',
+            weight: 100,
+            quality: 2.5,
+            mainhands: [
+                {
+                    stack: { item: 'twilightforest:gold_minotaur_axe', nbt: default_nbt },
+                    weight: 100,
+                    drop_chance: 0.085
+                }
+            ],
+            offhands: [],
+            helmets: [],
+            chestplates: [],
+            leggings: [],
+            boots: [
+                {
+                    stack: {
+                        item: 'minecraft:leather_boots',
+                        nbt: Object.assign(reactive.earth_snare, enchant_glint.blank, enchantments.reactive_4)
+                    },
+                    weight: 100,
+                    drop_chance: 0.0
+                }
+            ],
+            tags: ['miniboss/minotaur']
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.addJson(`${id_prefix}${recipe.name}.json`, recipe);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/apotheosis/minibosses/twilightforest.js
+++ b/kubejs/server_scripts/base/recipes/apotheosis/minibosses/twilightforest.js
@@ -265,6 +265,156 @@ ServerEvents.highPriorityData((event) => {
                     }
                 ]
             }
+        },
+        {
+            id: 'troll',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['twilightforest:troll'],
+            valid_gear_sets: ['#miniboss/troll'],
+            dimensions: [],
+            affixed: false,
+            nbt: {},
+            stats: {
+                enchant_chance: 0.0,
+                enchantment_levels: [10, 10, 10, 10],
+                effects: [
+                    { effect: 'minecraft:strength', amplifier: 1, chance: 1.0 },
+                    { effect: 'minecraft:regeneration', amplifier: 2, chance: 1.0 }
+                ],
+                attribute_modifiers: [
+                    {
+                        attribute: 'minecraft:generic.max_health',
+                        operation: 'ADDITION',
+                        value: 40
+                    },
+                    {
+                        attribute: 'minecraft:generic.attack_knockback',
+                        operation: 'ADDITION',
+                        value: 1.5
+                    },
+                    {
+                        attribute: 'minecraft:generic.attack_damage',
+                        operation: 'MULTIPLY_BASE',
+                        value: { min: 0.35, steps: 35, step: 0.02 }
+                    },
+                    {
+                        attribute: 'minecraft:generic.knockback_resistance',
+                        operation: 'ADDITION',
+                        value: 0.5
+                    },
+                    {
+                        attribute: 'minecraft:generic.armor',
+                        operation: 'ADDITION',
+                        value: 4
+                    },
+                    {
+                        attribute: 'minecraft:generic.armor_toughness',
+                        operation: 'ADDITION',
+                        value: 2
+                    }
+                ]
+            }
+        },
+        {
+            id: 'minotaur',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['twilightforest:minotaur'],
+            valid_gear_sets: ['#miniboss/minotaur'],
+            dimensions: [],
+            affixed: false,
+            nbt: {},
+            stats: {
+                enchant_chance: 1.0,
+                enchantment_levels: [50, 50, 50, 50],
+                effects: [{ effect: 'minecraft:strength', amplifier: 1, chance: 1.0 }],
+                attribute_modifiers: [
+                    {
+                        attribute: 'minecraft:generic.max_health',
+                        operation: 'ADDITION',
+                        value: 20
+                    },
+                    {
+                        attribute: 'minecraft:generic.attack_knockback',
+                        operation: 'ADDITION',
+                        value: 1.5
+                    },
+                    {
+                        attribute: 'minecraft:generic.attack_damage',
+                        operation: 'MULTIPLY_BASE',
+                        value: { min: 0.35, steps: 35, step: 0.02 }
+                    },
+                    {
+                        attribute: 'minecraft:generic.knockback_resistance',
+                        operation: 'ADDITION',
+                        value: 0.5
+                    },
+                    {
+                        attribute: 'minecraft:generic.armor',
+                        operation: 'ADDITION',
+                        value: 6
+                    },
+                    {
+                        attribute: 'minecraft:generic.armor_toughness',
+                        operation: 'ADDITION',
+                        value: 4
+                    }
+                ]
+            }
+        },
+        {
+            id: 'minoshroom',
+            name: null,
+            chance: 1.0,
+            weight: 100,
+            quality: 0,
+            entities: ['twilightforest:minoshroom'],
+            valid_gear_sets: ['#miniboss/minoshroom'],
+            dimensions: [],
+            affixed: false,
+            nbt: {},
+            stats: {
+                enchant_chance: 1.0,
+                enchantment_levels: [50, 50, 50, 50],
+                effects: [{ effect: 'minecraft:strength', amplifier: 1, chance: 1.0 }],
+                attribute_modifiers: [
+                    {
+                        attribute: 'minecraft:generic.max_health',
+                        operation: 'ADDITION',
+                        value: 20
+                    },
+                    {
+                        attribute: 'minecraft:generic.attack_knockback',
+                        operation: 'ADDITION',
+                        value: 1.5
+                    },
+                    {
+                        attribute: 'minecraft:generic.attack_damage',
+                        operation: 'MULTIPLY_BASE',
+                        value: { min: 0.35, steps: 35, step: 0.02 }
+                    },
+                    {
+                        attribute: 'minecraft:generic.knockback_resistance',
+                        operation: 'ADDITION',
+                        value: 0.5
+                    },
+                    {
+                        attribute: 'minecraft:generic.armor',
+                        operation: 'ADDITION',
+                        value: 6
+                    },
+                    {
+                        attribute: 'minecraft:generic.armor_toughness',
+                        operation: 'ADDITION',
+                        value: 4
+                    }
+                ]
+            }
         }
     ];
 

--- a/kubejs/server_scripts/constants/equipment_nbt.js
+++ b/kubejs/server_scripts/constants/equipment_nbt.js
@@ -507,7 +507,7 @@ const reactive = {
                         size: 8
                     },
                     sound: { pitch: 0.5, soundTag: { id: 'ars_nouveau:fire_family_2' }, volume: 1.0 },
-                    spellColor: { b: 1, g: 90, r: 255 }
+                    spellColor: { b: 1, g: 90, r: 255, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -534,7 +534,7 @@ const reactive = {
                         size: 10
                     },
                     sound: { pitch: 0.5, soundTag: { id: 'ars_nouveau:fire_family_2' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 25, r: 30 }
+                    spellColor: { b: 255, g: 25, r: 30, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -557,7 +557,7 @@ const reactive = {
                         size: 6
                     },
                     sound: { pitch: 1.0, soundTag: { id: 'ars_nouveau:fire_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 255, r: 25 }
+                    spellColor: { b: 255, g: 255, r: 25, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -584,7 +584,7 @@ const reactive = {
                         size: 10
                     },
                     sound: { pitch: 0.6, soundTag: { id: 'ars_nouveau:gaia_family' }, volume: 1.0 },
-                    spellColor: { b: 25, g: 255, r: 25 }
+                    spellColor: { b: 25, g: 255, r: 25, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -608,7 +608,7 @@ const reactive = {
                         size: 7
                     },
                     sound: { pitch: 1.0, soundTag: { id: 'ars_nouveau:fire_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 25, r: 80 }
+                    spellColor: { b: 255, g: 25, r: 80, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -628,7 +628,7 @@ const reactive = {
                         size: 3
                     },
                     sound: { pitch: 1.0, soundTag: { id: 'ars_nouveau:fire_family' }, volume: 1.0 },
-                    spellColor: { b: 25, g: 255, r: 25 }
+                    spellColor: { b: 25, g: 255, r: 25, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -651,7 +651,7 @@ const reactive = {
                         size: 6
                     },
                     sound: { pitch: 0.4, soundTag: { id: 'ars_nouveau:tempestry_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 25, r: 80 }
+                    spellColor: { b: 255, g: 25, r: 80, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -673,7 +673,7 @@ const reactive = {
                         size: 5
                     },
                     sound: { pitch: 2.55, soundTag: { id: 'ars_nouveau:tempestry_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 25, r: 80 }
+                    spellColor: { b: 255, g: 25, r: 80, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -695,7 +695,7 @@ const reactive = {
                         size: 5
                     },
                     sound: { pitch: 0.01, soundTag: { id: 'ars_nouveau:tempestry_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 25, r: 80 }
+                    spellColor: { b: 255, g: 25, r: 80, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -715,7 +715,7 @@ const reactive = {
                         size: 3
                     },
                     sound: { pitch: 1.0, soundTag: { id: 'ars_nouveau:fire_family' }, volume: 1.0 },
-                    spellColor: { b: 1, g: 74, r: 150 }
+                    spellColor: { b: 1, g: 74, r: 150, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -736,7 +736,7 @@ const reactive = {
                         size: 4
                     },
                     sound: { pitch: 1.67, soundTag: { id: 'ars_nouveau:tempestry_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 255, r: 255 }
+                    spellColor: { b: 255, g: 255, r: 255, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -759,7 +759,7 @@ const reactive = {
                         size: 6
                     },
                     sound: { pitch: 0.01, soundTag: { id: 'ars_nouveau:tempestry_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 25, r: 30 }
+                    spellColor: { b: 255, g: 25, r: 30, type: 'ars_nouveau:constant' }
                 }
             }
         }
@@ -786,7 +786,30 @@ const reactive = {
                         size: 10
                     },
                     sound: { pitch: 1.67, soundTag: { id: 'ars_nouveau:tempestry_family' }, volume: 1.0 },
-                    spellColor: { b: 255, g: 255, r: 255 }
+                    spellColor: { b: 255, g: 255, r: 255, type: 'ars_nouveau:constant' }
+                }
+            }
+        }
+    },
+    ground_slam: {
+        'ars_nouveau:reactive_caster': {
+            current_slot: 0,
+            flavor: '',
+            spell_count: 1,
+            spells: {
+                spell0: {
+                    name: '',
+                    recipe: {
+                        part0: 'ars_nouveau:glyph_underfoot',
+                        part1: 'ars_nouveau:glyph_linger',
+                        part2: 'toomanyglyphs:glyph_filter_living_not_monster',
+                        part3: 'ars_nouveau:glyph_launch',
+                        part4: 'toomanyglyphs:glyph_amplify_two',
+                        part5: 'ars_nouveau:glyph_gust',
+                        size: 6
+                    },
+                    sound: { pitch: 1.0, soundTag: { id: 'ars_nouveau:gaia_family' }, volume: 1.0 },
+                    spellColor: { b: 255, g: 25, r: 80, type: 'ars_nouveau:constant' }
                 }
             }
         }

--- a/kubejs/server_scripts/expert/advancements/occultism.js
+++ b/kubejs/server_scripts/expert/advancements/occultism.js
@@ -1,0 +1,46 @@
+/// High Priority required or Apotheosis over-writes these.
+/*
+enchantment_levels: [50, 30, 120, 40],
+    level at which normal items are enchanted
+    (same when ench module is disabled)
+    level at which the affix item is enchanted
+    (same when ench module is disable)
+
+*/
+ServerEvents.highPriorityData((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const id_prefix = 'occultism:advancements/occultism/';
+
+    const advancements = [
+        {
+            parent: 'occultism:occultism/root',
+            criteria: {
+                death_tome_gate_small: {
+                    conditions: {
+                        ritual_predicate: {
+                            ritual_id: 'enigmatica:expert/occultism/ritual/death_tome_gate_small'
+                        }
+                    },
+                    trigger: 'occultism:ritual'
+                }
+            },
+            display: {
+                announce_to_chat: false,
+                description: { translate: 'advancements.occultism.death_tome_gate_small.description' },
+                frame: 'task',
+                hidden: true,
+                icon: { item: 'occultism:jei_dummy/none' },
+                show_toast: false,
+                title: { translate: 'advancements.occultism.death_tome_gate_small.title' }
+            },
+            requirements: [['death_tome_gate_small']]
+        }
+    ];
+
+    advancements.forEach((advancement) => {
+        event.addJson(`${id_prefix}${advancement.id}.json`, advancement);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/mekanism/nucleosynthesizing.js
+++ b/kubejs/server_scripts/expert/recipes/mekanism/nucleosynthesizing.js
@@ -57,9 +57,9 @@ ServerEvents.recipes((event) => {
         {
             output: Item.of(
                 'industrialforegoing:infinity_drill',
-                '{CanCharge:1b,Energy:0L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"POOR",Special:0b}'
+                '{CanCharge:1b,Energy:9223372036854775807L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"ARTIFACT",Special:0b}'
             ).toJson(),
-            gasInput: { gas: 'mekanism:antimatter', amount: 100 },
+            gasInput: { gas: 'mekanism:antimatter', amount: 1000 },
             itemInput: { ingredient: { item: 'immersiveengineering:drillhead_steel' } },
             duration: 1200,
             id: `${id_prefix}infinity_drill`
@@ -67,9 +67,9 @@ ServerEvents.recipes((event) => {
         {
             output: Item.of(
                 'industrialforegoing:infinity_saw',
-                '{CanCharge:1b,Energy:0L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"POOR",Special:0b}'
+                '{CanCharge:1b,Energy:9223372036854775807L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"ARTIFACT",Special:0b}'
             ).toJson(),
-            gasInput: { gas: 'mekanism:antimatter', amount: 100 },
+            gasInput: { gas: 'mekanism:antimatter', amount: 1000 },
             itemInput: { ingredient: { item: 'immersiveengineering:rockcutter' } },
             duration: 1200,
             id: `${id_prefix}infinity_saw`
@@ -77,9 +77,9 @@ ServerEvents.recipes((event) => {
         {
             output: Item.of(
                 'industrialforegoing:infinity_hammer',
-                '{Beheading:0,CanCharge:1b,Energy:0L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"POOR",Special:0b}'
+                '{Beheading:0,CanCharge:1b,Energy:9223372036854775807L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"ARTIFACT",Special:0b}'
             ).toJson(),
-            gasInput: { gas: 'mekanism:antimatter', amount: 100 },
+            gasInput: { gas: 'mekanism:antimatter', amount: 1000 },
             itemInput: { ingredient: { item: 'hexerei:warhammer' } },
             duration: 1200,
             id: `${id_prefix}infinity_hammer`
@@ -87,9 +87,9 @@ ServerEvents.recipes((event) => {
         {
             output: Item.of(
                 'industrialforegoing:infinity_trident',
-                '{CanCharge:1b,Channeling:0b,Energy:0L,Fluid:{Amount:0,FluidName:"biofuel"},Loyalty:0,Riptide:0,Selected:"POOR",Special:0b}'
+                '{CanCharge:1b,Channeling:0b,Energy:9223372036854775807L,Fluid:{Amount:0,FluidName:"biofuel"},Loyalty:0,Riptide:0,Selected:"ARTIFACT",Special:0b}'
             ).toJson(),
-            gasInput: { gas: 'mekanism:antimatter', amount: 100 },
+            gasInput: { gas: 'mekanism:antimatter', amount: 1000 },
             itemInput: { ingredient: { item: 'minecraft:trident' } },
             duration: 1200,
             id: `${id_prefix}infinity_trident`
@@ -97,9 +97,9 @@ ServerEvents.recipes((event) => {
         {
             output: Item.of(
                 'industrialforegoing:infinity_nuke',
-                '{CanCharge:1b,Energy:0L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"POOR",Special:0b}'
+                '{CanCharge:1b,Energy:9223372036854775807L,Fluid:{Amount:0,FluidName:"biofuel"},Selected:"ARTIFACT",Special:0b}'
             ).toJson(),
-            gasInput: { gas: 'mekanism:antimatter', amount: 100 },
+            gasInput: { gas: 'mekanism:antimatter', amount: 1000 },
             itemInput: { ingredient: { item: 'thermal:earth_tnt' } },
             duration: 1200,
             id: `${id_prefix}infinity_nuke`


### PR DESCRIPTION
-   [Expert] Infinity Tools are now crafted directly at Artifact tier as they are end game tools.
-  Fixed some bugged quest loot in the Nature's Aura chapter. 
-   Cave Trolls have been buffed with regeneration and knockback effects. 
-   Minotaurs and Minoshrooms can now snare you, making them very dangerous in packs. 
- Death Tome quest now has an associated advancement to assist in triggering it from the ritual. 