### PR TITLE
Make Compacting Drawers give Copper Nuggets when Copper Ingot/Block is inserted first + Fix for #587

### DIFF
--- a/config/inventorysorter-client.toml
+++ b/config/inventorysorter-client.toml
@@ -4,5 +4,5 @@
 	#Sorting module
 	sortingmodule = true
 	#Wheel move module
-	wheelmovemodule = true
+	wheelmovemodule = false
 

--- a/defaultconfigs/inventorysorter-client.toml
+++ b/defaultconfigs/inventorysorter-client.toml
@@ -1,8 +1,0 @@
-
-#Inventory sorter modules
-[modules]
-	#Sorting module
-	sortingmodule = true
-	#Wheel move module
-	wheelmovemodule = false
-

--- a/defaultconfigs/inventorysorter-client.toml
+++ b/defaultconfigs/inventorysorter-client.toml
@@ -4,5 +4,5 @@
 	#Sorting module
 	sortingmodule = true
 	#Wheel move module
-	wheelmovemodule = true
+	wheelmovemodule = false
 

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -302,7 +302,10 @@ ServerEvents.recipes((event) => {
         { id: 'thermal:machines/pulverizer/pulverizer_apatite' },
         { id: 'thermal:machines/pulverizer/pulverizer_cinnabar' },
         { id: 'thermal:machines/pulverizer/pulverizer_niter' },
-        { id: 'thermal:machines/pulverizer/pulverizer_sulfur' }
+        { id: 'thermal:machines/pulverizer/pulverizer_sulfur' },
+
+        // Fix for copper ingots not being possible to obtain from Compacting Drawers (https://github.com/EnigmaticaModpacks/Enigmatica9/issues/537)
+        { id: 'immersiveengineering:crafting/nugget_copper_to_copper_ingot'}
     ];
 
     colors.forEach((color) => {

--- a/kubejs/server_scripts/base/recipes/enigmatica/shaped.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/shaped.js
@@ -1,0 +1,19 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/enigmatica/shaped/';
+
+    const recipes = [
+        {
+            output: 'minecraft:copper_ingot',
+            pattern: ['NNN', 'NNN', 'NNN'],
+            // Not using tag here to force FunctionalStorage to choose that nugget, instead of checking a tag and failing. Fix for https://github.com/EnigmaticaModpacks/Enigmatica9/issues/537
+            key: {
+                N: 'emendatusenigmatica:copper_nugget'
+            },
+            id: `${id_prefix}copper_ingot_from_nuggets`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});


### PR DESCRIPTION
This PR resolves #537 and #587

# #537
The issue described in 537 wasn't major, however it was a bit irritating 😅

https://github.com/EnigmaticaModpacks/Enigmatica9/assets/60540476/dae6d7f6-d7bc-45a6-8757-9c03f8ea95ff

The video represents Compacting Drawers now working properly :D It is fast and short because of the github limit, but it does the job done 😅

The only compromise here is lack of tags in the required recipe to make this work, however I think that is worth sacrifice, as in practice no one should get non-EE copper nuggets!

# #587
Issue 587 was just a simple config change, that might got forgotten in the pask 2 weeks 😅 I included the fix in this PR instead of doing second one