### PR TITLE
General Improvements

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -38,6 +38,7 @@
 -   And even more quest typos and clarifications [\#644](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/644) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] Remove Tablet of Summon Wilden from all loot tables [\#660](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/660) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed some bugged quest loot in the Nature's Aura chapter. [\#661](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/661) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Fixed localization for Withered Souls. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed typos in quests [\#632](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/632) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed typos in quests [\#639](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/639) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed typos in quests [\#652](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/652) ([MuteTiefling](https://github.com/MuteTiefling))

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -26,6 +26,12 @@
 -   Kelp and Seaweed may be purchased from the market.[\#668](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/668) ([MuteTiefling](https://github.com/MuteTiefling))
 -   [Expert] Sushi Go Crafting cooking devices are now accessible pre iron.[\#668](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/668) ([MuteTiefling](https://github.com/MuteTiefling))
 -   A new skeleton, Skeletal Tempest Caller has a chance to spawn.[\#668](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/668) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Water Essence may now be used to make Prismarine. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Raw Ironwood may now be quadrupled by Water Essence in a Metallurgic Infuser. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Sculk requirements for endgame are reduced further. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Osmium may now be converted to Armor Shards. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Hex glyph available earlier. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Ars Elemental upgrades now require Spellbound Invar instead of Netherite. [\#673](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/673) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -11,6 +11,7 @@
     "item.kubejs.alchemists_delight": "Alchemist's Delight",
 
     "item.kubejs.amethyst_dust": "Amethyst Dust",
+    "item.kubejs.withered_soul": "Withered Soul",
     "item.kubejs.tree_of_life_1": "Tree of Life: Stage 1",
     "item.kubejs.tree_of_life_2": "Tree of Life: Stage 2",
     "item.kubejs.tree_of_life_3": "Tree of Life: Stage 3",

--- a/kubejs/server_scripts/expert/recipes/ars_elemental/armor_upgrade.js
+++ b/kubejs/server_scripts/expert/recipes/ars_elemental/armor_upgrade.js
@@ -1,0 +1,27 @@
+ServerEvents.recipes((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const id_prefix = 'enigmatica:expert/ars_elemental/armor_upgrade/';
+    const recipes = [];
+
+    // Replace Netherite with Compressed Iron
+    event.forEachRecipe({ type: 'ars_elemental:armor_upgrade' }, (r) => {
+        let found = recipes.some((recipe) => recipe.id === r.getId());
+        let recipe = JSON.parse(r.json);
+        recipe.pedestalItems.push({ item: { tag: 'forge:ingots/compressed_iron' } });
+        recipe.pedestalItems.map((pedestalItem) => {
+            if (pedestalItem.item.tag == 'forge:ingots/netherite') {
+                pedestalItem.item.tag = 'forge:ingots/compressed_iron';
+            }
+            return pedestalItem;
+        });
+        if (!found) event.custom(recipe).id(r.getId());
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'ars_elemental:armor_upgrade';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
@@ -121,6 +121,21 @@ ServerEvents.recipes((event) => {
             count: 1,
             exp: 55,
             id: 'ars_elemental:glyph_phantom_grasp'
+        },
+        {
+            output: 'ars_nouveau:glyph_hex',
+            inputItems: [
+                { item: { item: 'ars_nouveau:abjuration_essence' } },
+                { item: { item: 'hexerei:belladonna_berries' } },
+                { item: { item: 'minecraft:blaze_rod' } },
+                { item: { item: 'minecraft:blaze_rod' } },
+                { item: { item: 'minecraft:blaze_rod' } },
+                { item: { item: 'ars_elemental:anima_essence' } },
+                { item: { item: 'supplementaries:antique_ink' } }
+            ],
+            count: 1,
+            exp: 160,
+            id: 'ars_nouveau:glyph_hex'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -180,6 +180,7 @@ ServerEvents.recipes((event) => {
         { id: 'immersiveengineering:crafting/redstone_breaker' },
         { id: 'immersiveengineering:crafting/breaker_switch' },
         { id: 'immersiveengineering:crafting/cloche' },
+        { id: 'immersiveengineering:crafting/paper_from_sawdust' },
         { id: 'immersiveengineering:blueprint/electron_tube' },
         { id: 'immersiveengineering:blueprint/component_electronic' },
         { id: 'immersiveengineering:blueprint/light_bulb' },

--- a/kubejs/server_scripts/expert/recipes/industrialforegoing/stonework_generate.js
+++ b/kubejs/server_scripts/expert/recipes/industrialforegoing/stonework_generate.js
@@ -19,6 +19,14 @@ ServerEvents.recipes((event) => {
             lavaConsume: 0,
             waterConsume: 0,
             id: `${id_prefix}sourcestone`
+        },
+        {
+            output: { item: 'occultism:otherstone', count: 1 },
+            lavaNeed: 1000,
+            waterNeed: 1000,
+            lavaConsume: 0,
+            waterConsume: 0,
+            id: `${id_prefix}otherstone`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/expert/recipes/mekanism/metallurgic_infusing.js
@@ -42,6 +42,30 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}osmium_dirty_dust`
         },
         {
+            output: { item: 'minecraft:prismarine_shard' },
+            itemInput: { ingredient: { item: 'ae2:certus_quartz_crystal' } },
+            chemicalInput: { infuse_type: 'emendatusenigmatica:water_essence', amount: 5 },
+            id: `${id_prefix}prismarine_shard`
+        },
+        {
+            output: { item: 'minecraft:prismarine_crystals' },
+            itemInput: { ingredient: { item: 'ae2:charged_certus_quartz_crystal' } },
+            chemicalInput: { infuse_type: 'emendatusenigmatica:water_essence', amount: 5 },
+            id: `${id_prefix}prismarine_crystals`
+        },
+        {
+            output: { item: 'twilightforest:ironwood_ingot', count: 4 },
+            itemInput: { ingredient: { tag: 'forge:ores/ironwood' } },
+            chemicalInput: { infuse_type: 'emendatusenigmatica:water_essence', amount: 10 },
+            id: `${id_prefix}ironwood_ingot`
+        },
+        {
+            output: { item: 'twilightforest:armor_shard' },
+            itemInput: { ingredient: { tag: 'forge:nuggets/osmium' } },
+            chemicalInput: { infuse_type: 'emendatusenigmatica:earth_essence', amount: 10 },
+            id: `${id_prefix}armor_shard`
+        },
+        {
             output: { item: 'emendatusenigmatica:nickel_dirty_dust', count: 2 },
             itemInput: { ingredient: { tag: 'mekanism:clumps/nickel' } },
             chemicalInput: { infuse_type: 'emendatusenigmatica:earth_essence', amount: 20 },

--- a/kubejs/server_scripts/expert/recipes/powah/energizing.js
+++ b/kubejs/server_scripts/expert/recipes/powah/energizing.js
@@ -23,9 +23,9 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}crystal_spirited`
         },
         {
-            output: '2x powah:crystal_nitro',
+            output: '4x powah:crystal_nitro',
             inputs: ['#forge:pellets/polonium', 'quark:red_rune', '#forge:pellets/polonium'],
-            energy: '12800000',
+            energy: '25600000',
             id: `${id_prefix}crystal_nitro`
         },
         {

--- a/kubejs/server_scripts/expert/recipes/thermal/crystallizer.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/crystallizer.js
@@ -7,8 +7,8 @@ ServerEvents.recipes((event) => {
     const recipes = [
         {
             ingredients: [
-                { fluid: 'kubejs:elysium', amount: 50 },
-                { item: 'minecraft:sculk', count: 9 }
+                { fluid: 'kubejs:elysium', amount: 100 },
+                { item: 'minecraft:sculk', count: 3 }
             ],
             result: [{ item: 'minecraft:echo_shard' }],
             energy: 12000,


### PR DESCRIPTION
- [Expert] Fixed localization for Withered Souls. 
- [Expert] New recipes for Prismarine:
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/6f176003-4346-4e30-b11e-48ff52321f5e)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/3c9740d5-4ed3-41f1-89c8-4dc160a66591)
- [Expert] Raw Ironwood may now be quadrupled by Water Essence in a Metallurgic Infuser
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/cd86b131-8c13-4f5d-a84e-ef5f79f7ece0)
- [Expert] Sculk requirements for endgame are reduced further.
- [Expert] Osmium may now be converted to Armor Shards. 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/72ea92bb-4724-4681-9dbb-57109119a7f4)
-   [Expert] Hex glyph available earlier. 
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/de5d4d79-a823-4675-a358-d60cf817c439)
- [Expert] Ars Elemental upgrades now require Spellbound Invar instead of Netherite
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/3c9643d4-3f54-4731-9546-0615764c4e72)


