### PR TITLE
Improved quests

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🌟 Improvements
 
 -   [Expert] Framed Storage controller recipe is now inline with the regular Storage controller. [\#679](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/679) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Quests leading up to the various teleportation quests now grant the required advancement. These are also granted by simply holding the items for the quest, however, this ensures players in teams don't have to pass the item around just to gain the advancement. [\#683](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/683) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   [Expert] Shady Wizards no longer sell Wilden Tablets. [\#679](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/679) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Disabled Quark Hoe Harvesting to fix an issue it causes with Nature's Blessing. [\#679](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/679) ([MuteTiefling](https://github.com/MuteTiefling))
 -   Fixed unclear description text on Tallow. [\#679](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/679) ([MuteTiefling](https://github.com/MuteTiefling))
+-   [Expert] Honey Compass advancement now triggers when obtaining the compass, rather than on craft. [\#679](https://github.com/EnigmaticaModpacks/Enigmatica9/pull/679) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ---
 

--- a/config/ftbquests/quests/chapters/chapter_three.snbt
+++ b/config/ftbquests/quests/chapters/chapter_three.snbt
@@ -165,20 +165,36 @@
 				""
 				"Undoubtedly, it will help anchor a teleportation ritual to wherever they call home. "
 			]
+			icon: "powah:steel_energized"
 			id: "04B0F0BE6E54D620"
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
-				icon: "kubejs:scavengers_delight"
-				id: "691C3737512BE3BF"
-				player_command: false
-				title: "Scavenger's Delight"
-				type: "command"
-			}]
-			tasks: [{
-				id: "0D1ED0C7EDB28A00"
-				item: "powah:steel_energized"
-				type: "item"
-			}]
+			rewards: [
+				{
+					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+					icon: "kubejs:scavengers_delight"
+					id: "691C3737512BE3BF"
+					player_command: false
+					title: "Scavenger's Delight"
+					type: "command"
+				}
+				{
+					advancement: "restrictedportals:end"
+					criterion: ""
+					id: "4EEF35180F07D1C8"
+					type: "advancement"
+				}
+			]
+			tasks: [
+				{
+					id: "0D1ED0C7EDB28A00"
+					item: "powah:steel_energized"
+					type: "item"
+				}
+				{
+					id: "2DE3D3ADAD7B8032"
+					item: "rftoolsbase:infused_enderpearl"
+					type: "item"
+				}
+			]
 			x: 0.0d
 			y: -0.5d
 		}
@@ -633,14 +649,22 @@
 			}
 			id: "4F90F6437D6CF7EC"
 			min_width: 250
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
-				icon: "kubejs:aura_leaf"
-				id: "1D4D0A4842116B56"
-				player_command: false
-				title: "Aura Infusion"
-				type: "command"
-			}]
+			rewards: [
+				{
+					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
+					icon: "kubejs:aura_leaf"
+					id: "1D4D0A4842116B56"
+					player_command: false
+					title: "Aura Infusion"
+					type: "command"
+				}
+				{
+					advancement: "restrictedportals:nether"
+					criterion: ""
+					id: "258686773ADAF792"
+					type: "advancement"
+				}
+			]
 			shape: "hexagon"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/chapter_two.snbt
+++ b/config/ftbquests/quests/chapters/chapter_two.snbt
@@ -425,6 +425,12 @@
 					title: "The Queen's Guard"
 					type: "command"
 				}
+				{
+					advancement: "restrictedportals:overworld"
+					criterion: ""
+					id: "31B0F8BB850C792B"
+					type: "advancement"
+				}
 			]
 			shape: "hexagon"
 			tasks: [
@@ -552,11 +558,19 @@
 			icon: "minecraft:beehive"
 			id: "2153EBB1D50F0039"
 			min_width: 300
-			rewards: [{
-				id: "6363919C99636DBD"
-				item: "minecraft:ender_pearl"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "6363919C99636DBD"
+					item: "minecraft:ender_pearl"
+					type: "item"
+				}
+				{
+					advancement: "restrictedportals:bumblezone"
+					criterion: ""
+					id: "2E1997D119E6F3A3"
+					type: "advancement"
+				}
+			]
 			shape: "hexagon"
 			tasks: [
 				{

--- a/kubejs/server_scripts/expert/advancements/the_bumblezone.js
+++ b/kubejs/server_scripts/expert/advancements/the_bumblezone.js
@@ -271,6 +271,29 @@ ServerEvents.highPriorityData((event) => {
             },
             criteria: { impossible: { trigger: 'minecraft:impossible' } },
             requirements: [['impossible']]
+        },
+        {
+            id: 'tools/honey_compass_recipe',
+            parent: 'the_bumblezone:the_bumblezone/combs_and_beeswax/honey_cocoon_silk_touch',
+            display: {
+                icon: { item: 'the_bumblezone:honey_compass' },
+                title: { translate: 'advancements.the_bumblezone.honey_compass_recipe.title' },
+                description: { translate: 'advancements.the_bumblezone.honey_compass_recipe.description' },
+                frame: 'task',
+                show_toast: true,
+                announce_to_chat: false,
+                hidden: false
+            },
+            rewards: { experience: 5 },
+            criteria: {
+                honey_compass: {
+                    trigger: 'minecraft:inventory_changed',
+                    conditions: {
+                        items: [{ items: ['the_bumblezone:honey_compass'] }]
+                    }
+                }
+            },
+            requirements: [['honey_compass']]
         }
     ];
 


### PR DESCRIPTION
Expert quests leading up to the various teleportation quests now grant the required advancement. These are also granted by simply holding the items for the quest, however, this ensures players in teams don't have to pass the item around just to gain the advancement. 