### PR TITLE
Quest refresh

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🐛 Fixed Bugs
 
 -   Fix broken Necrotic Focus recipe [\#721](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/721)
+-   Fixed an erroneouos reference to Blitz that should be Blizz [\#724](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/724)
 
 ---
 

--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -19,7 +19,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "16C28EC18C21F2F9"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -45,7 +44,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4D335664F4D4ED3D"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -106,7 +104,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2688B8B2145804A6"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -130,7 +127,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0F35EC2C40562447"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -158,7 +154,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "337B225FE339F43B"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -192,7 +187,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "573D3073F3908571"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -223,7 +217,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0DD466F9E4C971CA"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -254,7 +247,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "01F67F64BFB7E5B9"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -283,7 +275,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "158A6753A48CF984"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -312,7 +303,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "34D5FB644519CBF0"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -347,7 +337,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2A5FF8DDEF6001FE"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -383,7 +372,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1F0EE9EF2D994337"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -409,7 +397,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4B4A7A5379592E0F"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -450,7 +437,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "712F6C181EE8F2A6"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -538,7 +524,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1CB7078D2013A45D"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -589,7 +574,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "37DEEE5854DDC9C3"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -658,7 +642,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2FD4EE828E4E5D5A"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -693,7 +676,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "744F2422F54D69DA"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -720,7 +702,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "72F01E6C29DAF100"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -748,7 +729,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3246307964E6DCA5"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -777,7 +757,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "6578D4689D6017B3"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -817,7 +796,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "03BA42DAD3DB4772"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -859,7 +837,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "60910F5984D9A60E"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -887,7 +864,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5BDD792D8C64CDF3"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -915,7 +891,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "2F0C078854BD0C27"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -939,7 +914,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "33D8C58732E28B40"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -984,7 +958,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7E47FD3643956FCE"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/applied_energistics_2_expert.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2_expert.snbt
@@ -31,7 +31,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4F04543FFF72A9BD"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -55,7 +54,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5CA8480BEB290EE9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -83,7 +81,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "01BF4CB94D87B2BF"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -117,7 +114,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "332B628F01F6ACC8"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -148,7 +144,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2191B6E99F2D07AD"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -179,7 +174,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "15402D7A6B44E06D"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -208,7 +202,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "60E138B701BF7801"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -237,7 +230,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1E9648A738A38B54"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -272,7 +264,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "67827C9AA3B11001"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -308,7 +299,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0B9B7C9D9C4B7E3C"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -334,7 +324,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "73050A813C48DF48"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -375,7 +364,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "404BC61163C2C12B"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -463,7 +451,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "05BD8A1423C36C57"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -514,7 +501,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "328112AEC0ACFA08"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -583,7 +569,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "19C4E8870DEE24D3"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -618,7 +603,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "255A9411D3B4D8FC"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -645,7 +629,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4523DC97AA9D7388"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -673,7 +656,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "15C35DA822BB37E1"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -702,7 +684,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7201CC8D7142B3D1"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -742,7 +723,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "520888C8211BEEC9"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -784,7 +764,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7C383955F6661648"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -809,7 +788,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5AF2CC718C7B645A"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -835,7 +813,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "78266754B7850F70"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -859,7 +836,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "09CFB74977302E69"
-				player_command: false
 				title: "Rare Applied Energistics Loot Box"
 				type: "command"
 			}]
@@ -904,7 +880,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ae2/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "165D78BF236C3E68"
-				player_command: false
 				title: "Epic Applied Energistics Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -24,7 +24,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "03F44B1EF1267DE4"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -94,7 +93,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0F9F1DDF26525F9B"
-					player_command: false
 					title: "Rare Ars Nouveau Loot Box"
 					type: "command"
 				}
@@ -154,7 +152,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000005FB"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -253,7 +250,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000005FC"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -353,7 +349,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000005FE"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -374,7 +369,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000009EC"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -439,7 +433,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000602"
-					player_command: false
 					title: "Rare Ars Nouveau Loot Box"
 					type: "command"
 				}
@@ -484,7 +477,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0000000000000CAD"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -552,7 +544,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7C201B55C9F00AD3"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -589,7 +580,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3B92D3705AEB3AA2"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -672,7 +662,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "13A4D5D0FB6AAF30"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -706,7 +695,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "185995ACE655011B"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -757,7 +745,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0E0F5F21781358A3"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -789,7 +776,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "55CCE0392547A82F"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -816,7 +802,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "658E6A4D80FA8301"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -871,7 +856,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "37131D5E140365A2"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1035,7 +1019,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "096125B9A6DA61DE"
-					player_command: false
 					title: "Rare Ars Nouveau Loot Box"
 					type: "command"
 				}
@@ -1043,7 +1026,6 @@
 					command: "/execute at @p run summon minecraft:chicken ~ ~2 ~"
 					icon: "minecraft:egg"
 					id: "6F26AB1474F756FC"
-					player_command: false
 					title: "Summon Chicken"
 					type: "command"
 				}
@@ -1070,7 +1052,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "4C18E35BD71FC9C6"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1102,7 +1083,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "32BD6621BA65DF4F"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1143,7 +1123,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3C644C0B2495BC36"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1163,7 +1142,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "5A6342EB078DF159"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -1184,7 +1162,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "5C7AAD35F5713448"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1205,7 +1182,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "32B10294788455A9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1226,7 +1202,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "3F826BECBAC65089"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1247,7 +1222,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "5DD6D62E0C457716"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1275,7 +1249,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6DB8DF770C37C6FF"
-				player_command: false
 				title: "Ars Nouveau Rare Loot Box"
 				type: "command"
 			}]
@@ -1392,7 +1365,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "4D5943A28084DA51"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1426,7 +1398,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "10635CFA99A607DE"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1508,7 +1479,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "097A6D19CCF1D16F"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1575,7 +1545,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "49268BE6F3E1218B"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1596,7 +1565,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "708695DC518FA6AA"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1621,7 +1589,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "20587DF83A9CDEE2"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1656,7 +1623,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "054C8C6E78EF9712"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1818,7 +1784,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "597B10860B9F7082"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1878,7 +1843,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "5FBCFC8E2A3A9F7F"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1992,7 +1956,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "554D391BC7B04832"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -2019,7 +1982,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "25797A58CD3FB9E7"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2040,7 +2002,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6AB5D94A72FBBE3B"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2061,7 +2022,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "71EE3CB169F23535"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2086,7 +2046,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "74DC74F14E5469F2"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2106,7 +2065,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7AC95168237AF555"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2135,7 +2093,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7CE9FDA5D58E4515"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2243,7 +2200,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2E298084349A0FDF"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2273,7 +2229,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6B0B1FC4330D47D7"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2331,7 +2286,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "65B241E708BDD124"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
@@ -24,7 +24,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "2657A594991D427A"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -114,7 +113,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "66680508E51439EA"
-					player_command: false
 					title: "Rare Ars Nouveau Loot Box"
 					type: "command"
 				}
@@ -174,7 +172,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3CC381888EA0B5BC"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -208,7 +205,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "489E57E94749C830"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -278,7 +274,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6CC66A4B5F8AC37D"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -377,7 +372,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "631CD8944CF3CC6C"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -398,7 +392,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "06700B179BAB6F8A"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -463,7 +456,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "54C27B605C9C3467"
-					player_command: false
 					title: "Rare Ars Nouveau Loot Box"
 					type: "command"
 				}
@@ -508,7 +500,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "7DF496221DDAC5FB"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -576,7 +567,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5E08CDEBE8129227"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -606,7 +596,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3BD42A0AC8B961F5"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -689,7 +678,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "674D0E1D98CD7AB5"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -723,7 +711,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1FF9BB5244F19212"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -774,7 +761,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0F5F7260808060F4"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -806,7 +792,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "283F604BA1282333"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -833,7 +818,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6FF58044D0712C64"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -888,7 +872,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1EC4616A0AE0C8D6"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1053,7 +1036,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "528D9A6C163EB60E"
-					player_command: false
 					title: "Rare Ars Nouveau Loot Box"
 					type: "command"
 				}
@@ -1061,7 +1043,6 @@
 					command: "/execute at @p run summon minecraft:chicken ~ ~2 ~"
 					icon: "minecraft:egg"
 					id: "2FEDBAF01DD0BF91"
-					player_command: false
 					title: "Summon Chicken"
 					type: "command"
 				}
@@ -1087,7 +1068,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2F18780C98316591"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1128,7 +1108,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "457C21ABFA7637A4"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1148,7 +1127,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "7F01E8DAF2CD0183"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -1169,7 +1147,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "03F61C5A1DBBF074"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1190,7 +1167,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "113DE4E30F0603AE"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1211,7 +1187,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "593888B6FAFA3B6F"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1232,7 +1207,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "7F1942734DAE17E5"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1260,7 +1234,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5D1D40D3A5BD2188"
-				player_command: false
 				title: "Ars Nouveau Rare Loot Box"
 				type: "command"
 			}]
@@ -1388,7 +1361,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "523A8D4D80FE8B39"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1422,7 +1394,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "642BD46DC846AFF0"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1504,7 +1475,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "1048A87DBDEFDC94"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1571,7 +1541,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "053B675C08203E63"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -1592,7 +1561,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "180E24818B168713"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1617,7 +1585,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6AFAD8CCB8F9D632"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1652,7 +1619,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0B82FDABF3529573"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1814,7 +1780,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "3047EFF4240BBC13"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1874,7 +1839,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "19CF0E8800F47D68"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1988,7 +1952,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "2A9F65EAFE5906AE"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -2015,7 +1978,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "71B1B07111E7AB15"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2036,7 +1998,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7DDA37A921481C1B"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2057,7 +2018,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "27D2395B64750346"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2082,7 +2042,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "102B3BDDD0DF27CF"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2102,7 +2061,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0091925FA6883E6C"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2131,7 +2089,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3F0E66EDE94551C5"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2239,7 +2196,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "713E65CAD400D0B1"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2269,7 +2225,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6CE800DF409875BD"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]
@@ -2327,7 +2282,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/ars_nouveau/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1F5953E382A8C9C2"
-				player_command: false
 				title: "Rare Ars Nouveau Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/automation.snbt
+++ b/config/ftbquests/quests/chapters/automation.snbt
@@ -24,7 +24,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "0000000000000968"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -56,7 +55,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000A5D"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -179,7 +177,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "239155FDD340ECAF"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -248,7 +245,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "3922A588208AF529"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -281,7 +277,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "3C512C78B12406AA"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -318,7 +313,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "30E1EC30981D6B46"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -686,7 +680,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7E251F2D83DBC6E3"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -714,7 +707,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "621F32F72099BE12"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -931,7 +923,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "27AFD476C3E9CE35"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -976,7 +967,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "56004BEDB4624F96"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -996,7 +986,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "16F20BC236C77741"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1063,7 +1052,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "67EA54AB859657A6"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1193,7 +1181,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "08DE601136922190"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1213,7 +1200,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2243774A0B86BB25"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1233,7 +1219,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2AD1A7E7FBED5577"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1257,7 +1242,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "27427773186BCFB8"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1281,7 +1265,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5DA8602DB0ED0DF3"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1307,7 +1290,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "36E4235895E38D38"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1368,7 +1350,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "21186E3E79CE729E"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1411,7 +1392,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "50603CD292ADFE2D"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1442,7 +1422,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "59C423C8FAA91053"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/building.snbt
+++ b/config/ftbquests/quests/chapters/building.snbt
@@ -49,7 +49,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "73CEB3BC6963B644"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -83,7 +82,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7E2D7FEE20672C9D"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -311,7 +309,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "31F796972A4B7369"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -600,7 +597,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "384957F4FCE7BC6A"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -636,7 +632,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "01870BF5EE173AB5"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -694,7 +689,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0A09BABD778C97C2"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -762,7 +756,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5596D763FED920E0"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -25,7 +25,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "60A777DE4B85ED0F"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -79,7 +78,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 				icon: "kubejs:aura_leaf"
 				id: "74F868CAED853121"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -111,7 +109,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "7447FA9138D4E94E"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -140,7 +137,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 				icon: "kubejs:aura_leaf"
 				id: "4C4DBF8114CB2E51"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -171,7 +167,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 				icon: "kubejs:aura_leaf"
 				id: "0BF68F0E91094483"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -225,7 +220,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "39B68CC0E19837B6"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -290,7 +284,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "6F2498DE79248A40"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -370,7 +363,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "5414F5E5DBF5FCA4"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -450,7 +442,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0E5BD92301912FBE"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -552,7 +543,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "63EC6BE1C18F9E9A"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -560,7 +550,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/medium"
 					icon: "kubejs:aura_leaf"
 					id: "38C17BE6339B21BC"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -651,7 +640,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "5CD17C5FC1E99147"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -793,7 +781,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "29AD14E62D652876"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -806,7 +793,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "6BEDB6EB5F5DD15C"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -874,7 +860,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "181F9F12E4654AC3"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -899,7 +884,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "0CEB7353C721EF23"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -932,7 +916,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "368322B66A743C01"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -940,7 +923,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "43B5455E97D1AB02"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -974,7 +956,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "51CCBDE9F54731C8"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -982,7 +963,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "35079413F0D062FB"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1018,7 +998,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "3C9CCE31C80E1348"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1026,7 +1005,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "11B3DE3B0795BA69"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1054,7 +1032,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "61B34E18FBDA8BE6"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1062,7 +1039,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "06804245F30E2149"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1097,7 +1073,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:ars_nouveau_glyph_cache/tier_1"
 				icon: "ars_nouveau:blank_glyph"
 				id: "4D3BD7740EAF736F"
-				player_command: false
 				title: "Random Tier 1 Glyph"
 				type: "command"
 			}]
@@ -1146,7 +1121,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "07DDF6CFF702FA3E"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1154,7 +1128,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "1411C2FA9E44E9AE"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1186,7 +1159,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "624D22F8BB99AF09"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1232,7 +1204,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "75C613BBF99219CD"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1240,7 +1211,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "5B324D5035FAA45D"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1275,7 +1245,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "5986A05AFF7B5081"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1391,7 +1360,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5C4A1E2E0AC85142"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1442,7 +1410,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "11AB85F4A8D711C2"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1488,7 +1455,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "5D0ACAACAA68E0CD"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1540,7 +1506,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "11443A06230EBBDC"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1625,7 +1590,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "5961092F4097FD3E"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1660,7 +1624,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "56ACF42C5D91BAF5"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1709,7 +1672,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "5177B763DE66FC8D"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1755,7 +1717,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "0BD0FAEB5CF42323"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1763,7 +1724,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "4F929950817CCC3E"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -1816,7 +1776,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "389C33B783F1A41E"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -1846,7 +1805,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2D22DA949427C0B4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1868,7 +1826,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "651C07D976AD902F"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -1973,7 +1930,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "65C797E604B3DA0F"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -2013,7 +1969,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "5BAC9CC4EA1BAEEC"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -2087,7 +2042,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "46B73E0A24DE5D55"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -2132,7 +2086,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 					icon: "kubejs:aura_leaf"
 					id: "2136A5B6580847A6"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -2176,7 +2129,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 				icon: "kubejs:aura_leaf"
 				id: "44AF536691C6AFC3"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -2203,7 +2155,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "13E73AB24BADDF67"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -2247,7 +2198,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "6D4844BFC44CD5D5"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -2287,7 +2237,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "5C504E7B50DF72CA"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -2315,7 +2264,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "53223E0F43F27F71"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -2349,7 +2297,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "0278C7667B0EC3FE"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -2392,7 +2339,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "69D3102DD62060D9"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -2400,7 +2346,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "0BE9EBECF0414FE5"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -2429,7 +2374,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "67BBB8A5B92C7AE7"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -2437,7 +2381,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "6A9DEFBAF39BE8C7"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -2587,7 +2530,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "64D8345AD1B57F8B"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/chapter_three.snbt
+++ b/config/ftbquests/quests/chapters/chapter_three.snbt
@@ -20,7 +20,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "73146FCB5DE34BD0"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -28,7 +27,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "4A56772129E93DBD"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -57,7 +55,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "240F67E11441400B"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -81,7 +78,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "435BC41E9248DDA9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -107,7 +103,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "19B4DB02EEC8719A"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -172,7 +167,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "691C3737512BE3BF"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -216,7 +210,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "0505511F544D9B32"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -254,7 +247,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "626DB2BAB756CD14"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -293,7 +285,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "27C72A314A0835DD"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -320,7 +311,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "0139AC85B01E713C"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -364,7 +354,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "6E801CF58CCC17F1"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -401,7 +390,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "79B5374F289BE361"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -438,7 +426,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "6EC8C22079A42D8F"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -475,7 +462,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "24D145AA7990A26D"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -517,7 +503,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "0FC494420DB000EC"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -541,7 +526,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0015D006738A40B6"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -569,7 +553,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2275D9F976F77BDF"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -604,7 +587,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "617415D046BDABDF"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -654,7 +636,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "1D4D0A4842116B56"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -703,7 +684,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "48DA2969D0098400"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -801,11 +781,11 @@
 					id: "37C787A2F4CB8129"
 					item: {
 						Count: 1b
-						id: "thermal:blitz_spawn_egg"
+						id: "thermal:blizz_spawn_egg"
 						tag: {
 							display: {
-								Lore: ["{\"translate\":\"item.kubejs.ritual_summon_bound_blitz.tooltip\"}"]
-								Name: "{\"translate\":\"item.kubejs.ritual_summon_bound_blitz\"}"
+								Lore: ["{\"translate\":\"item.kubejs.ritual_summon_bound_blizz.tooltip\"}"]
+								Name: "{\"translate\":\"item.kubejs.ritual_summon_bound_blizz\"}"
 							}
 						}
 					}
@@ -832,7 +812,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7A03B91B11415840"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -856,7 +835,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 				icon: "kubejs:aura_leaf"
 				id: "109F6B48B5CA4221"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -876,7 +854,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "43BF2A66732C89E4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -903,7 +880,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "0874E8DB1A76AE45"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -986,7 +962,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/small"
 				icon: "kubejs:aura_leaf"
 				id: "4014F4C50BC08A30"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -1031,7 +1006,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "6C551A3BE7841241"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/chapter_two.snbt
+++ b/config/ftbquests/quests/chapters/chapter_two.snbt
@@ -46,7 +46,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "4C9ACBB578AFC307"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -102,7 +101,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "57F9A2443CFDEB47"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -137,7 +135,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 				icon: "kubejs:aura_leaf"
 				id: "2D791DABDEA4EA64"
-				player_command: false
 				title: "Aura Infusion"
 				type: "command"
 			}]
@@ -295,7 +292,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "363F6A8483473ED2"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -413,7 +409,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "21E8E534E6A7EBA6"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -421,7 +416,6 @@
 					command: "/execute at @p run summon the_bumblezone:beehemoth ~ ~2 ~"
 					icon: "the_bumblezone:bee_queen_spawn_egg"
 					id: "1F7EF0E9FB5A71ED"
-					player_command: false
 					title: "The Queen's Guard"
 					type: "command"
 				}
@@ -526,7 +520,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "23B342C9B1B2B79C"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -613,7 +606,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "14AC976E409BBD66"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -651,7 +643,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4F02BC40CABDEFBD"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -684,7 +675,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "72393E06B7289A9F"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -692,7 +682,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/large"
 					icon: "kubejs:aura_leaf"
 					id: "5C8EE393AD050F66"
-					player_command: false
 					title: "Aura Infusion"
 					type: "command"
 				}
@@ -789,7 +778,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "42238537475907E4"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/create.snbt
+++ b/config/ftbquests/quests/chapters/create.snbt
@@ -129,7 +129,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000D75"
-					player_command: false
 					title: "Epic Create Loot Box"
 					type: "command"
 				}
@@ -195,7 +194,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0000000000000D74"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -261,7 +259,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000D79"
-					player_command: false
 					title: "Rare Create Loot Box"
 					type: "command"
 				}
@@ -300,7 +297,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D78"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -343,7 +339,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D77"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -379,7 +374,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D83"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -412,7 +406,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D81"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -455,7 +448,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D7A"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -483,7 +475,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D7B"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -517,7 +508,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000D5C"
-					player_command: false
 					title: "Legendary Create Loot Box"
 					type: "command"
 				}
@@ -544,7 +534,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D7C"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -610,7 +599,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D7D"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -643,7 +631,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D7E"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -672,7 +659,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000D58"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -698,7 +684,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D72"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -731,7 +716,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000D54"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -762,7 +746,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D6F"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -798,7 +781,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000D68"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -852,7 +834,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D71"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -881,7 +862,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D70"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -916,7 +896,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D5E"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -943,7 +922,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000D55"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -972,7 +950,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D84"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1002,7 +979,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D86"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1031,7 +1007,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000D5A"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1058,7 +1033,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D89"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1096,7 +1070,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D6E"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1124,7 +1097,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2C441D0D6266C526"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1235,7 +1207,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000D69"
-					player_command: false
 					title: "Rare Create Loot Box"
 					type: "command"
 				}
@@ -1289,7 +1260,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D6A"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1314,7 +1284,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D6B"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1358,7 +1327,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D64"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1386,7 +1354,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D60"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1407,7 +1374,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D61"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1432,7 +1398,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D63"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1459,7 +1424,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D62"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1490,7 +1454,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D5F"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1530,7 +1493,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D6C"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1556,7 +1518,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000D5D"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1586,7 +1547,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000D88"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1612,7 +1572,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000D82"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1638,7 +1597,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6E8C331AB8382D16"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1663,7 +1621,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000D56"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1691,7 +1648,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4DF5697B73CC2E0D"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1721,7 +1677,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "1B26E3707C1728A2"
-					player_command: false
 					title: "Legendary Create Loot Box"
 					type: "command"
 				}
@@ -1764,7 +1719,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "50DD42ECCFA5F58A"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1844,7 +1798,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "71903E436C628975"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1869,7 +1822,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "06E0FA67CB6CC271"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1894,7 +1846,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "618ED2BF01169851"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1916,7 +1867,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "613E951A3993ECB9"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1945,7 +1895,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "3A6CBAD9FE3C2776"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1972,7 +1921,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "18498D3FE01276FC"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/create_expert.snbt
+++ b/config/ftbquests/quests/chapters/create_expert.snbt
@@ -136,7 +136,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "265E3903847F3130"
-					player_command: false
 					title: "Epic Create Loot Box"
 					type: "command"
 				}
@@ -202,7 +201,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7F6B1C3C3F88F766"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -269,7 +267,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "6701BD22C891A0F5"
-					player_command: false
 					title: "Rare Create Loot Box"
 					type: "command"
 				}
@@ -308,7 +305,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "78FA2D541E288B56"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -351,7 +347,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "689DB92C44140D9D"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -387,7 +382,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "37B5190441657460"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -420,7 +414,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5DA3139CCB2387ED"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -463,7 +456,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "62C35306B67B2809"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -491,7 +483,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5710F5B07DBCE190"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -525,7 +516,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "039581C4AD45A4C3"
-					player_command: false
 					title: "Legendary Create Loot Box"
 					type: "command"
 				}
@@ -552,7 +542,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0F1A62465CBB42D6"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -618,7 +607,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "21CE398AFABF3FC8"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -651,7 +639,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5272BC579D3D9836"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -680,7 +667,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0A7D176961C23E15"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -706,7 +692,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "02080084ABF0EECA"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -739,7 +724,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "5464DCCBFDF03454"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -770,7 +754,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "533389DECD3DB973"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -806,7 +789,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "5044588C6DA5D045"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -860,7 +842,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "20A5EC236DC4A972"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -889,7 +870,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "634D74739A220234"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -924,7 +904,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0AF701A6E011A769"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -951,7 +930,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "17932E9C90BF9F0B"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -980,7 +958,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "563CFD1505CBBC00"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1010,7 +987,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "513969EA94AFA47D"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1039,7 +1015,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "757E5C7AB9DC87FF"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1070,7 +1045,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "34E1C82BFD5BD409"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1094,7 +1068,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2D708C8085FCBB03"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1205,7 +1178,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "48B4464DBD40B9D0"
-					player_command: false
 					title: "Rare Create Loot Box"
 					type: "command"
 				}
@@ -1259,7 +1231,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4494D69A52071143"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1284,7 +1255,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1597FC0ADBA5E7C9"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1328,7 +1298,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "378F3AE6697344A6"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1356,7 +1325,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "6ED3255791EBD190"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1377,7 +1345,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "28C9B593F7559123"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1402,7 +1369,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "54F79A04D05AC440"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1429,7 +1395,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "001C17D5D029CEEE"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1460,7 +1425,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "22E781622F117752"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1495,7 +1459,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "762027CFF1BB1983"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1521,7 +1484,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "129FC9D4B142A885"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1551,7 +1513,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "12FECCF21E3A5E81"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1577,7 +1538,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "615974670DD4392E"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1603,7 +1563,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4258C881DD19230C"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1628,7 +1587,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "4BD7F5A9A1818D77"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1656,7 +1614,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2573803F64C9B873"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1686,7 +1643,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "730DADB4DB8FCE64"
-					player_command: false
 					title: "Legendary Create Loot Box"
 					type: "command"
 				}
@@ -1729,7 +1685,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "76589AD67CFA6AA0"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1813,7 +1768,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4D53FA0D11747F26"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1838,7 +1792,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "4F43163D2CBCABEF"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]
@@ -1863,7 +1816,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "30DE8FD2BCB34418"
-				player_command: false
 				title: "Epic Create Loot Box"
 				type: "command"
 			}]
@@ -1885,7 +1837,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4CE1F858B1237850"
-				player_command: false
 				title: "Rare Create Loot Box"
 				type: "command"
 			}]
@@ -1914,7 +1865,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/create/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "4A9E638F4D1CD688"
-				player_command: false
 				title: "Legendary Create Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -27,7 +27,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000A93"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/hexerei.snbt
+++ b/config/ftbquests/quests/chapters/hexerei.snbt
@@ -24,7 +24,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "1E0DFFC73941A14F"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -32,7 +31,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "4FB8BBEE3A960D17"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -93,7 +91,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "039ACBE8A55777ED"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -101,7 +98,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "3218C1F002704552"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -127,7 +123,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "5F87C71456C2B384"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -157,7 +152,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "17FBE554BB08FC90"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -165,7 +159,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3D780F0BB9395E99"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -210,7 +203,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "7C4A5CEF72FA19B0"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -240,7 +232,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0BA444C12A4208F7"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -248,7 +239,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "6066E7AA064A4A84"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -290,7 +280,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "66F8B950553302ED"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -298,7 +287,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "6E805DAF31BF8B2F"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -327,7 +315,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "6046E95DF2F2CE3C"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -335,7 +322,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "084995A471301D0B"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -382,7 +368,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "17B9E2556914F03E"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -433,7 +418,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "126BDC3ABFDCB2E8"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -441,7 +425,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "1C912EEB2ADBC94C"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -484,7 +467,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "102164B44FAAE49A"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -492,7 +474,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "5AE710FB7FB5283B"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -515,7 +496,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "6A715E8A2FF7A4F5"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -523,7 +503,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "4D9EACBE361B48B3"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -555,7 +534,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "6CF6DDE26468F7CA"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -563,7 +541,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0B6657C33AECA812"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -654,7 +631,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "1DAEF5BD5864A7A6"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -662,7 +638,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "01A521B4A99F153C"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -710,7 +685,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "7F63F43AC11BCF99"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -718,7 +692,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "5EA1F6B798CC3A78"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -776,7 +749,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "4AB4040559B83C3E"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -806,7 +778,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "1C75F799457CB9FE"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -814,7 +785,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "32CDF56407E67438"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -841,7 +811,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "7F24002EAAA4E329"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -849,7 +818,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7C6758B634970F76"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/hexerei_expert.snbt
+++ b/config/ftbquests/quests/chapters/hexerei_expert.snbt
@@ -24,7 +24,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "7D5E908EC9DE9715"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -32,7 +31,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "4E5A44CFE98B911C"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -93,7 +91,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "73C8B33466F4D4F5"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -101,7 +98,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "2C83DEA7BCE4D5F6"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -127,7 +123,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "7268A0D63151C75C"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -157,7 +152,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "5F486CA7E6D10B56"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -165,7 +159,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7B89FA27DB1AF100"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -210,7 +203,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "26053E7A8577AEDF"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -240,7 +232,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "03BD72914A1D5B9D"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -248,7 +239,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3DA1CA9DFD62B517"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -290,7 +280,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "76F8AD34ED2A1D87"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -298,7 +287,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "546A5956FC94CA6E"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -327,7 +315,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "66955850C37FE65A"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -335,7 +322,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "2173E38F058618F7"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -382,7 +368,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "046D627EA75B7F8F"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -433,7 +418,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "2A1D5A2B94310D21"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -441,7 +425,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "2DF6CEBE0C4B3EEA"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -484,7 +467,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "5C04993CA46D530E"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -492,7 +474,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "2080E81678E500BF"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -515,7 +496,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "62A06F40EC110553"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -523,7 +503,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "5655A323A6A9076E"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -555,7 +534,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "7283CC64122E8015"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -563,7 +541,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "32F4AAD7197D4E70"
-					player_command: false
 					title: "Rare Hexerei Loot Box"
 					type: "command"
 				}
@@ -651,7 +628,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "629C0100CFA99E07"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -659,7 +635,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "77AF61904F0FFD0D"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -707,7 +682,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "09A30010B022472D"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -715,7 +689,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "29255C286BC7A1AA"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -773,7 +746,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "693F4BD1CEBBB904"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -803,7 +775,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "55630D935774736C"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}
@@ -811,7 +782,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "6AC6C7A90D19B9E8"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -838,7 +808,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "3839C03CB49C1A83"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -846,7 +815,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/hexerei/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "25E2D68E1252E742"
-					player_command: false
 					title: "Epic Hexerei Loot Box"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/immersive_engineering.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering.snbt
@@ -66,7 +66,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "14FA4A24C7409F77"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -171,7 +170,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "479085DC8961252C"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -217,7 +215,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "35F82EC15261CF27"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -326,7 +323,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "000000000000060D"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -370,7 +366,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000614"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -423,7 +418,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "42A6A92476A1E6A3"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -471,7 +465,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "4077FA420E15CA1E"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -515,7 +508,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000060E"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -552,7 +544,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000621"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -598,7 +589,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "72236F0E6C545F53"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -632,7 +622,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000620"
-					player_command: false
 					title: "Epic Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -670,7 +659,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000622"
-					player_command: false
 					title: "Epic Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -678,7 +666,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000623"
-					player_command: false
 					title: "Epic Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -702,7 +689,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000616"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -760,7 +746,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000061D"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -805,7 +790,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7FF68906D9C40250"
-					player_command: false
 					title: "Epic Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -842,7 +826,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000624"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -870,7 +853,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000061C"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -913,7 +895,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "35731B5937BBF8EB"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -936,7 +917,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000611"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -997,7 +977,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000612"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1021,7 +1000,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7B4485A51E367C74"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1045,7 +1023,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7C2DDDC233064BCB"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1069,7 +1046,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5D70006C425BF1CE"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1095,7 +1071,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "19DF31EC00072D95"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1129,7 +1104,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "70A61D684AF8B5FF"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1191,7 +1165,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5DA0CBAF1FE1884D"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1219,7 +1192,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2AD421A3854D9018"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1242,7 +1214,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2F46FE420C944733"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1272,7 +1243,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5BD3CDFF61F6D406"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1300,7 +1270,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "631502F52A0FC583"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1325,7 +1294,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "49F3E5B6240975FB"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1411,7 +1379,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "098BE70A0BFCDBDC"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -1517,7 +1484,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "57BCCB513CA91D6B"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -1561,7 +1527,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "24A27D154F9FB236"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1592,7 +1557,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1EE1E0D6A82D9B90"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1614,7 +1578,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "388801C14A6A9916"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1636,7 +1599,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "231932437B4E9839"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1662,7 +1624,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "41D458AFA503BEE3"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1698,7 +1659,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "673B7ECE0BDE897E"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1774,7 +1734,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "541EA45AC0E8D7CF"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1802,7 +1761,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5691DD3285ADB605"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1831,7 +1789,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "39097B6C7B38506A"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1865,7 +1822,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "713B059CB5DBEBCA"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1886,7 +1842,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "36142E0E21AC2474"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1912,7 +1867,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "764755F9CD548D84"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1956,7 +1910,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "23A03D539DC422B8"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1979,7 +1932,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1316D0601A8173BA"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2011,7 +1963,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5290F7C5440ABBF7"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2042,7 +1993,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "021D071CC21AB50B"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2074,7 +2024,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "062364A690B278A3"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2097,7 +2046,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "10CEE819901CA9C6"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2139,7 +2087,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "66C37DAE605D6CC9"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2184,7 +2131,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "012A851509C81D0B"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -2225,7 +2171,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "59AE772A27F7132F"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/immersive_engineering_expert.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering_expert.snbt
@@ -71,7 +71,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "7CF96DD04549C88E"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -125,7 +124,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "398CDC6CF25157E2"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -161,7 +159,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "46FD7B2580341B5A"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -198,7 +195,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "426A2E4DA6AFF591"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -244,7 +240,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "4154AF97AF351A81"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -278,7 +273,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "31244E3A165692D7"
-					player_command: false
 					title: "Epic Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -307,7 +301,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "40925150E26EAE3B"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -334,7 +327,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1066F6DE27800461"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -379,7 +371,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7911BAC7D49A5DDE"
-					player_command: false
 					title: "Epic Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -404,7 +395,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "539F9DA723B28F8D"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -428,7 +418,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4052FF9F57585C7E"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -452,7 +441,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "608E51DBB573ED51"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -478,7 +466,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3FFFB287BFADE2C3"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -512,7 +499,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2C35D352E74590B4"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -574,7 +560,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2CD8CE867708CD0B"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -602,7 +587,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5CE05E3DA7229475"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -625,7 +609,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5CCC54117C042EE1"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -655,7 +638,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "298946A9B451517E"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -683,7 +665,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "25E0E92F5231037D"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -708,7 +689,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4EEB280105923301"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -794,7 +774,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "7D5842BA0E299AD8"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -900,7 +879,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "3669742F4DB4E3E8"
-					player_command: false
 					title: "Rare Immersive Engineering Loot Box"
 					type: "command"
 				}
@@ -944,7 +922,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7D784913D9E8D959"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -975,7 +952,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3DD0A53CCD932C32"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -997,7 +973,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6D5DCD5F5DC44E15"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1019,7 +994,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4254ABCD3D800570"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1049,7 +1023,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4699D3CFC067C539"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1125,7 +1098,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "23B55FB82DC91FAD"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1153,7 +1125,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "006A3342779F3BF5"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1182,7 +1153,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2A1CB70A6FBC5D1C"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1211,7 +1181,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "618B24D59812DB2E"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1257,7 +1226,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2A30182F30E91A11"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1289,7 +1257,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "448576DF1369C86E"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1312,7 +1279,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "46E0B3AB7FBFB885"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1367,7 +1333,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "42D13B8C156E8F61"
-				player_command: false
 				title: "Rare Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1416,7 +1381,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7AB92C9D40AE07DD"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]
@@ -1457,7 +1421,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/immersive_engineering/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0D5AB91F6CD6CDC5"
-				player_command: false
 				title: "Epic Immersive Engineering Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -91,7 +91,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000629"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -140,7 +139,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000062A"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -183,7 +181,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000631"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -225,7 +222,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000636"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -256,7 +252,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000635"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -328,7 +323,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000637"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -426,7 +420,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "369D530DD7F97732"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -486,7 +479,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000062B"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -525,7 +517,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00EAC9D358EBDA6E"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -596,7 +587,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3468583C0AA86050"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -663,7 +653,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7448C2CFAE0B9B0C"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -737,7 +726,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "263A38AB486FB333"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -808,7 +796,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "47D97D1C9814403A"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -845,7 +832,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6600C08CC24C5889"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -895,7 +881,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2538800DB4CB1107"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -945,7 +930,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "05F8498BBE9C52E7"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1059,7 +1043,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "35A7641EB7485F84"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1113,7 +1096,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "237A67715D34F6C0"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1145,7 +1127,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "545227BDC3D56D52"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1180,7 +1161,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "39D92F4F432AB139"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1226,7 +1206,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0A5DDA176392D6E1"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1247,7 +1226,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "759901F1E0E1D611"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1274,7 +1252,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "75698CB62EFD1F72"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1299,7 +1276,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "7F04572BDD87A1BF"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1326,7 +1302,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2E9F2ABF8D261788"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1350,7 +1325,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "34E4B9B36B6E6628"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1371,7 +1345,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "52072317D15EFCBE"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1393,7 +1366,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "37E1065325FCB784"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1428,7 +1400,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "64C3B3C120222D87"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -1468,7 +1439,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "1568C7AD4AE0329B"
-					player_command: false
 					title: "Epic Industrial Foregoing Loot Box"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/industrial_foregoing_expert.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing_expert.snbt
@@ -50,7 +50,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "379E1DF360B71C28"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -94,7 +93,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6719F2C0C0E7FB2B"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -139,7 +137,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "3EF8435392E86386"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -167,7 +164,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "35FD9DE9C1AE9790"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -209,7 +205,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "076765969F37C975"
-					player_command: false
 					title: "Rare Industrial Foregoing Loot Box"
 					type: "command"
 				}
@@ -238,7 +233,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5C407B1EF44A000F"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -281,7 +275,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "55819A4D04CED075"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -321,7 +314,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6C27923990829FB4"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -395,7 +387,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2CF35E56988649E5"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -435,7 +426,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "131B8F1A1F1FE1FC"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -457,7 +447,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "58FC0103111007F7"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -485,7 +474,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0DB5BF86FD75C324"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -511,7 +499,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "56424275050ABFF4"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -539,7 +526,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3463EB949B33CDA9"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -560,7 +546,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "788C3E2A822F3CD0"
-				player_command: false
 				title: "Rare Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -582,7 +567,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "356398A4898C5D98"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -641,7 +625,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "770DD847637FC248"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]
@@ -681,7 +664,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/industrial_foregoing/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5C632F4FB5098CA3"
-				player_command: false
 				title: "Epic Industrial Foregoing Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -134,7 +134,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "000000000000080E"
-					player_command: false
 					title: "Rare Mekanism Loot Box"
 					type: "command"
 				}
@@ -163,7 +162,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000007D2"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -200,7 +198,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000086B"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -347,7 +344,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000816"
-					player_command: false
 					title: "Rare Mekanism Loot Box"
 					type: "command"
 				}
@@ -410,7 +406,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000812"
-					player_command: false
 					title: "Rare Mekanism Loot Box"
 					type: "command"
 				}
@@ -479,7 +474,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000810"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -529,7 +523,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000080F"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -551,7 +544,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2C053364C3C43F2B"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -690,7 +682,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "000000000000086C"
-					player_command: false
 					title: "Rare Mekanism Loot Box"
 					type: "command"
 				}
@@ -725,7 +716,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000081A"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -766,7 +756,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000818"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -943,7 +932,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000842"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -1004,7 +992,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000821"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1069,7 +1056,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000819"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1152,7 +1138,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000828"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1181,7 +1166,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000827"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -1244,7 +1228,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000823"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1271,7 +1254,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000826"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1322,7 +1304,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000822"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -1369,7 +1350,6 @@
 				command: "/mek radiation removeAll"
 				icon: "mekanism:radioactive_waste_barrel"
 				id: "00000000000007E6"
-				player_command: false
 				title: "Clear Radiation"
 				type: "command"
 			}]
@@ -1417,7 +1397,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000E7E"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1474,7 +1453,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3954C7F86F9C301B"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1503,7 +1481,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "21CAB75DA0FC846D"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1568,7 +1545,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "1AFDD071E6498280"
-					player_command: false
 					title: "Rare Mekanism Loot Box"
 					type: "command"
 				}
@@ -1623,7 +1599,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0EF5031647DF246B"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1677,7 +1652,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5401843104659A31"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1699,7 +1673,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4D7EBE6F46745564"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1732,7 +1705,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "72D2A9208D24A98B"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1769,7 +1741,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "1E132D1DA266F9D0"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1790,7 +1761,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "770BBC7C7D600050"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -1849,7 +1819,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "2786C62F6892FF5C"
-					player_command: false
 					title: "Epic Mekanism Loot Box"
 					type: "command"
 				}
@@ -1911,7 +1880,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0CC201E65BD42219"
-					player_command: false
 					title: "Epic Mekanism Loot Box"
 					type: "command"
 				}
@@ -1961,7 +1929,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "634296CEF122AE4A"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2052,7 +2019,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000836"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -2060,7 +2026,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000835"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -2068,7 +2033,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000834"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -2076,7 +2040,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000833"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -2121,7 +2084,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "02DDF1CE58F39392"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2171,7 +2133,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5762E181CAFC83C3"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2221,7 +2182,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "573E399EC0F34972"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2271,7 +2231,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0948EA5E17CDDD00"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2323,7 +2282,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "32FD23AB3F8DF34F"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2373,7 +2331,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "77C3F132A13834B7"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2423,7 +2380,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "018B8A4B7056741C"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2467,7 +2423,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6AD9F503A4FAA0DE"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2513,7 +2468,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3C7E6639087AC8A8"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2545,7 +2499,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "113BEAE9CFA03B42"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2573,7 +2526,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0C8D83D50C20F440"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2616,7 +2568,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "42CFD06BFE3E50B3"
-					player_command: false
 					title: "Epic Mekanism Loot Box"
 					type: "command"
 				}
@@ -2639,7 +2590,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "604D79E991EEDBE3"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2698,7 +2648,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "52117F946D809E51"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -2732,7 +2681,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0CEABA183C56B136"
-				player_command: false
 				title: "Epic Mekanism Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/mekanism_expert.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_expert.snbt
@@ -47,7 +47,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "03D6AC51756CA1AD"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -103,7 +102,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "131BF3970989B404"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -153,7 +151,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1958B307B1019C34"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -185,7 +182,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "2A335028425C54BC"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -232,7 +228,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "5A38C9C7570957F9"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]
@@ -261,7 +256,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "469F014669D8372A"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -290,7 +284,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5D6190F7A86AA552"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -340,7 +333,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "418966840E6DECD6"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -394,7 +386,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4E6A4987E188A34D"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -429,7 +420,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3F9BD229E827C77F"
-					player_command: false
 					title: "Epic Mekanism Loot Box"
 					type: "command"
 				}
@@ -521,7 +511,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "3CB100DC1C534B42"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -529,7 +518,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "222D45DF4BF00BC2"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -537,7 +525,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "1B429878EA149C2F"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -545,7 +532,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "48E391547CA0B9FE"
-					player_command: false
 					title: "Legendary Mekanism Loot Box"
 					type: "command"
 				}
@@ -590,7 +576,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3237A18C32BE6F14"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -610,7 +595,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7F95A852BA445BB5"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -635,7 +619,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "65A247D76D57636D"
-				player_command: false
 				title: "Rare Mekanism Loot Box"
 				type: "command"
 			}]
@@ -669,7 +652,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "6D14EA132AC6D0B8"
-					player_command: false
 					title: "Epic Mekanism Loot Box"
 					type: "command"
 				}
@@ -717,7 +699,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/mekanism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "6646042C11EB98C5"
-				player_command: false
 				title: "Legendary Mekanism Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -104,7 +104,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "000000000000035A"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -143,7 +142,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "000000000000035B"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -151,7 +149,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0000000000000A72"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -188,7 +185,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000373"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -217,7 +213,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000004A2"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -279,7 +274,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000369"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -314,7 +308,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000371"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -363,7 +356,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000378"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -385,7 +377,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000377"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -413,7 +404,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000367"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -441,7 +431,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000032D"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -463,7 +452,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000370"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -490,7 +478,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000036F"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -517,7 +504,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000036E"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -559,7 +545,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "3EF0E6B29460EC10"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -671,7 +656,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000362"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -699,7 +683,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000356"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -761,7 +744,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "20911E51DB4A9D8A"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -795,7 +777,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "1FF5A00AF41D494F"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -823,7 +804,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000863"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -910,7 +890,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000366"
-					player_command: false
 					title: "Epic Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -986,7 +965,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5685824F755FD107"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1016,7 +994,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "726807EBB03D8BE4"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1064,7 +1041,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "435589B2E3400026"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1089,7 +1065,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2078B2E2903D871C"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1114,7 +1089,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "398C537F585E06BA"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1134,7 +1108,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "64FB7A460234CA2F"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1155,7 +1128,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3DBA5D25A0607A73"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1176,7 +1148,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "108A5AC2A7832A0B"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1219,7 +1190,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "22036BC2088D50A5"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1349,7 +1319,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2C1BEB25E59B8F06"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1457,7 +1426,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "49FD9AE13A2A9FA3"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1506,7 +1474,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "790B02389C97D92B"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1564,7 +1531,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "6A253E63ACD97A02"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/natures_aura_expert.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura_expert.snbt
@@ -105,7 +105,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "36808DD105A48BCC"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -147,7 +146,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "1B3CC9578B9BF05D"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -155,7 +153,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "4D3CDE28F69D202C"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -192,7 +189,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "366B1FFE22EBE4E5"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -223,7 +219,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "097F8CAD66BB44FC"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -292,7 +287,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "5C2B4E261DE782E4"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -327,7 +321,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7B473B34257E6C77"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -376,7 +369,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7459B50D34DCEBD6"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -398,7 +390,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3CFF3CA727552A59"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -426,7 +417,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1E7F02A4791EFC1D"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -452,7 +442,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "11F0298FC3689734"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -475,7 +464,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "49064FB70F4C89F2"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -502,7 +490,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4E8906F53D1A0AB0"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -529,7 +516,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "30A356076A18628A"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -571,7 +557,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "1979E756D0AF7475"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -683,7 +668,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "230DB717CFF25F0B"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -711,7 +695,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "563C2C460079661B"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -773,7 +756,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "023260B9B7374F59"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -807,7 +789,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "470293D0FB403EA6"
-					player_command: false
 					title: "Rare Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -835,7 +816,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "139066FD1275A723"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -877,7 +857,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "1E29E1E01DA699F1"
-					player_command: false
 					title: "Epic Nature's Aura Loot Box"
 					type: "command"
 				}
@@ -942,7 +921,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7A33E6109905AF66"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -972,7 +950,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "455236A2B705B554"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1020,7 +997,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4429099A540470BF"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1045,7 +1021,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "20B45C4EAD3FE4CA"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1070,7 +1045,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "691D2626544B7801"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1090,7 +1064,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "7212F8AC7AC84191"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1111,7 +1084,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "28CC27FC10BC0B9B"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1132,7 +1104,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "1B9403D8A20F2898"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1175,7 +1146,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "44955606B0E1C7B5"
-				player_command: false
 				title: "Rare Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1305,7 +1275,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "2927D64D54B5FDD6"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]
@@ -1413,7 +1382,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "38D4D46D3976D5D6"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1462,7 +1430,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0CC83443C0E4A90D"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1520,7 +1487,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/natures_aura/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7FE6DA1A9A33BC3F"
-				player_command: false
 				title: "Epic Nature's Aura Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -78,7 +78,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000E22"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -126,7 +125,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "0000000000000CFB"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -154,7 +152,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000DFD"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -228,7 +225,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0000000000000E21"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -263,7 +259,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000E25"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -298,7 +293,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0DA435A9800123EC"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -306,7 +300,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "4FAC0A541EDA605E"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -340,7 +333,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "64B928DADA731482"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -348,7 +340,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "2D08D8D8EDB7FCA5"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -377,7 +368,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000E53"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -385,7 +375,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "03B4E985392B7110"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -423,7 +412,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000E6C"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -459,7 +447,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0E27087990A1AE2B"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -481,7 +468,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000E55"
-				player_command: false
 				title: "Occultism Legendary Loot Box"
 				type: "command"
 			}]
@@ -506,7 +492,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000E5D"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -536,7 +521,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000E5B"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -578,7 +562,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000E36"
-				player_command: false
 				title: "Occultism Epic Loot Chest"
 				type: "command"
 			}]
@@ -617,7 +600,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "120DF5E2156628C5"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -625,7 +607,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "5B611AD85C18BD01"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -655,7 +636,6 @@
 					command: "execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "0000000000000E48"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -663,7 +643,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000E49"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -705,7 +684,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000E67"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -739,7 +717,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000E68"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -772,7 +749,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000E37"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -810,7 +786,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "0000000000000E4A"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -818,7 +793,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "0000000000000E69"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -857,7 +831,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000E4E"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -865,7 +838,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "0000000000000E6A"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -901,7 +873,6 @@
 				command: "execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "0000000000000E45"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -928,7 +899,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "69B546B3BFC6B80E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -960,7 +930,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000DFC"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -995,7 +964,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000E3D"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -1003,7 +971,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0000000000000E3E"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -1011,7 +978,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "3B0ABDBA2725BC6D"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -1055,7 +1021,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000E44"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -1102,7 +1067,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000E50"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -1110,7 +1074,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "0000000000000E51"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -1143,7 +1106,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000E6F"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -1151,7 +1113,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000E70"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -1185,7 +1146,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3F636CC422DFEEDA"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -1193,7 +1153,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "6A3F63D2D3360EDE"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -1228,7 +1187,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000E23"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -1258,7 +1216,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000E76"
-				player_command: false
 				title: "Occultism Epic Loot Chest"
 				type: "command"
 			}]
@@ -1287,7 +1244,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "132D5C23B97D5E1F"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -1320,7 +1276,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "6CA0ED39817B0F4E"
-					player_command: false
 					title: "Occultism Legendary Loot Chest"
 					type: "command"
 				}
@@ -1328,7 +1283,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "55F8A50BA2FEEFF5"
-					player_command: false
 					title: "Occultism Legendary Loot Chest"
 					type: "command"
 				}
@@ -1360,7 +1314,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "63C1F20FAAC09395"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1415,7 +1368,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "541B0FFB87E21DA6"
-				player_command: false
 				title: "Occultism Epic Loot Chest"
 				type: "command"
 			}]
@@ -1439,7 +1391,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "664C3245FFD0C0A6"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1464,7 +1415,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "52E295A408C0602E"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1494,7 +1444,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "4D224E3CA3AF70CA"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/occultism_expert.snbt
+++ b/config/ftbquests/quests/chapters/occultism_expert.snbt
@@ -74,7 +74,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "10F35B67ABCD0BE9"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -99,7 +98,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "419B8DDAD1F2EFA8"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -167,7 +165,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "3C8C800F02B1B6BE"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -202,7 +199,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "2CC2443610E4CFF1"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -237,7 +233,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3B6224538F94ADC5"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -245,7 +240,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "1E48BCBE4012B685"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -279,7 +273,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7079CA0B9EE429C9"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -287,7 +280,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "2ACBBF255C72E5C5"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -316,7 +308,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "5994DD7843E5B711"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -324,7 +315,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "4E22EAB060EC7145"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -362,7 +352,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "50C50A413C996365"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -398,7 +387,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "678939723BB6DEB9"
-					player_command: false
 					title: "Occultism Epic Loot Chest"
 					type: "command"
 				}
@@ -420,7 +408,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "570703F75436A72B"
-				player_command: false
 				title: "Occultism Legendary Loot Box"
 				type: "command"
 			}]
@@ -445,7 +432,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "3DCB985BD8CD3A83"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -475,7 +461,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0375C6BE2CE4A248"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -517,7 +502,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4F87B6F409112BBE"
-				player_command: false
 				title: "Occultism Epic Loot Chest"
 				type: "command"
 			}]
@@ -558,7 +542,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "040FFFDF6D527A73"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -592,7 +575,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "28C55284F9DF058D"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -625,7 +607,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "26CBC35CB3182775"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -656,7 +637,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2786EF02B7121DF1"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -688,7 +668,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "54B802039174BA9A"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -723,7 +702,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "09704DE74B6D0FDF"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -731,7 +709,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "429B8A9FC14F374D"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -739,7 +716,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "7C2EBE033EADBC95"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -778,7 +754,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "36144539BED9E23C"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -823,7 +798,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "11289E089F55DC13"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -831,7 +805,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/legendary"
 					icon: "kubejs:legendary_lootbox"
 					id: "205E158A8C1DBFDD"
-					player_command: false
 					title: "Occultism Legendary Loot Box"
 					type: "command"
 				}
@@ -864,7 +837,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "5C1B16137B415C03"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -872,7 +844,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7F8FCF3FFACD8062"
-					player_command: false
 					title: "Occultism Epic Loot Box"
 					type: "command"
 				}
@@ -904,7 +875,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "79F50D4822BFDD4D"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -934,7 +904,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "337D8BD1DBAD5EE8"
-				player_command: false
 				title: "Occultism Epic Loot Chest"
 				type: "command"
 			}]
@@ -964,7 +933,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "14EB8F295FF2B7BB"
-				player_command: false
 				title: "Occultism Epic Loot Box"
 				type: "command"
 			}]
@@ -1002,7 +970,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "03243DB93AA2A084"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1058,7 +1025,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/occultism/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1A015AA19FC395D2"
-				player_command: false
 				title: "Occultism Epic Loot Chest"
 				type: "command"
 			}]
@@ -1082,7 +1048,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "030D9B9A9ED78D12"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1107,7 +1072,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "244C22E3F35C9074"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1137,7 +1101,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "2E3C0CEC5584142C"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/pneumaticcraft_repressurized.snbt
+++ b/config/ftbquests/quests/chapters/pneumaticcraft_repressurized.snbt
@@ -73,7 +73,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "00000000000000C6"
-					player_command: false
 					title: "Rare PNC:R Loot Box"
 					type: "command"
 				}
@@ -81,7 +80,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000A78"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -211,7 +209,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000000C5"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -314,7 +311,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00099FEE4C17C4F0"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -355,7 +351,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000000D8"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -470,7 +465,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000022C"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -604,7 +598,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000113"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -627,7 +620,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000117"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -687,7 +679,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000A7A"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -739,7 +730,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000122"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -776,7 +766,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000125"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -799,7 +788,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000128"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -892,7 +880,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000131"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -913,7 +900,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0000000000000134"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1013,7 +999,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000144"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1041,7 +1026,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7DF10C7739565EF2"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1069,7 +1053,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000150"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1096,7 +1079,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000154"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1131,7 +1113,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "000000000000015D"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1221,7 +1202,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "000000000000063D"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1306,7 +1286,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000433"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1343,7 +1322,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "0000000000000434"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1375,7 +1353,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000432"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1506,7 +1483,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000650"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1514,7 +1490,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "70699570CCD39B0A"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1522,7 +1497,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "672F3689E3C2339A"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1530,7 +1504,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "62C0239DB29248EF"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1605,7 +1578,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000A58"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -1696,7 +1668,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0000000000000A56"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1724,7 +1695,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "28F5EF7AA3A9A155"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1753,7 +1723,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "7593EC8DA1751738"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1788,7 +1757,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "3B79641BF92B19FF"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1809,7 +1777,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "16E0D7FE6BE0B32B"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1836,7 +1803,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "3B21A700E61C1016"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/pneumaticcraft_repressurized_expert.snbt
+++ b/config/ftbquests/quests/chapters/pneumaticcraft_repressurized_expert.snbt
@@ -71,7 +71,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7364D55166238332"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -165,7 +164,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "6E8BDFC4506F6E33"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -268,7 +266,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "29CC4AE5D8D278BA"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -309,7 +306,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "42EDFE52FEF7D948"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -424,7 +420,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2120D4C24F7F303D"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -557,7 +552,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "620CA924053FE1B1"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -580,7 +574,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "3621E6BD54CDE738"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -640,7 +633,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "4598DFE37D84B116"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -692,7 +684,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5D3612DC6DF205A4"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -728,7 +719,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "5600DC7079A960F8"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -751,7 +741,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "312B40790B0E6AE3"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -842,7 +831,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "09056410AC7B4F5E"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -863,7 +851,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "501A756DAB89889A"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -963,7 +950,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "05534AA4AD901FDD"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -991,7 +977,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "71C74EE7350259ED"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1025,7 +1010,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "33A65EE79C654898"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1114,7 +1098,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "14C53EBF59D4E97D"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1186,7 +1169,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "71E7B2F1A0C4BCF2"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1336,7 +1318,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "45F1066AD1B2C401"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1344,7 +1325,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0C55EECDCDE4C01C"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1352,7 +1332,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "320E3090BF091078"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1360,7 +1339,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0CE417ED326B8137"
-					player_command: false
 					title: "Epic PNC:R Loot Box"
 					type: "command"
 				}
@@ -1515,7 +1493,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0AF178227D43E923"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1543,7 +1520,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "624B43310C57D3AF"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1572,7 +1548,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1C96B75BC65D3936"
-				player_command: false
 				title: "Epic PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1607,7 +1582,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "03A761B743DDD4FD"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1628,7 +1602,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "15748F8C017B2B45"
-				player_command: false
 				title: "Rare PNC:R Loot Box"
 				type: "command"
 			}]
@@ -1655,7 +1628,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/pneumaticcraft/legendary"
 				icon: "kubejs:legendary_lootbox"
 				id: "3A10D0CC45A7D514"
-				player_command: false
 				title: "Legendary PNC:R Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -72,7 +72,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000288"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -130,7 +129,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000289"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -214,7 +212,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "074EB4DE8F4FF559"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -275,7 +272,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000064D"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -329,7 +325,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000028A"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -382,7 +377,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000064C"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -439,7 +433,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "2D695290477D3526"
-					player_command: false
 					title: "Powah Loot Box"
 					type: "command"
 				}
@@ -580,7 +573,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000028E"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -698,7 +690,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000028F"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -765,7 +756,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "51F5753437957980"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -818,7 +808,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000290"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -839,7 +828,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "09CDE670DE70DDAE"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -860,7 +848,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "15BA1F3744D7C2CF"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -880,7 +867,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "68CD30E38E3F5BF1"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -900,7 +886,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "37664B9288E40001"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -920,7 +905,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000294"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -942,7 +926,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4D1C32404BCA93FF"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]
@@ -997,7 +980,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/powah/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "4884AAB9BEA3FB71"
-				player_command: false
 				title: "Powah Loot Box"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/spirit.snbt
+++ b/config/ftbquests/quests/chapters/spirit.snbt
@@ -112,7 +112,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "70AD156DCAFD0200"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -189,7 +188,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "7AE09C2B127B056C"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -216,7 +214,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "43916A1487F20C59"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -240,7 +237,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "0B4C2A547E498C69"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -268,7 +264,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "6E37FF75A1558B1B"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -288,7 +283,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "5F1AF6109F3754D0"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -320,7 +314,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "77FCCB80FEB9BBB5"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -71,7 +71,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0000000000000A6B"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -109,7 +108,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "0000000000000A5E"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -135,7 +133,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "2D1E55B5A92B9F94"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -174,7 +171,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "00000000000009AB"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -214,7 +210,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "00000000000009A3"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -305,7 +300,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "00000000000009A1"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -350,7 +344,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "00000000000009AA"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -370,7 +363,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "695D02E01FA0C0BD"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -429,7 +421,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0000000000000A50"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -450,7 +441,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "000000000000099C"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -458,7 +448,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "0000000000000A6A"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -479,7 +468,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "000000000000099D"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -499,7 +487,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "0000000000000A51"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -555,7 +542,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "3E2CA8D755178794"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -615,7 +601,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "526E10A2F22FF97C"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -671,7 +656,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "2102EE1604B1EE96"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -765,7 +749,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "44BA68CC5061BD0A"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -894,7 +877,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "70E4602ABF82C34E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1039,7 +1021,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5B1B6013E6ED0715"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1083,7 +1064,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "6D5ED9C4BB24D5EA"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1135,7 +1115,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "54D08CA9D3C99DF7"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1159,7 +1138,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 				icon: "kubejs:alchemists_delight"
 				id: "5F17B44DFEC645FB"
-				player_command: false
 				title: "Alchemist's Delight"
 				type: "command"
 			}]
@@ -1183,7 +1161,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7BF2A0DA41927B29"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1223,7 +1200,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0B5190854F290B9D"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1267,7 +1243,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "6D9CB4B5D250FD85"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1315,7 +1290,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "677C92499FF4E2D8"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1335,7 +1309,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "53C384EC8266F233"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1414,7 +1387,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "54930DB1BCAFFAFC"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1473,7 +1445,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "683A154EC6984812"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/storage_expert.snbt
+++ b/config/ftbquests/quests/chapters/storage_expert.snbt
@@ -71,7 +71,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "5A22CB734A0F4FE3"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -165,7 +164,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "0F9CC40473CE9836"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -205,7 +203,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "4F1BD7539F45DA81"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -296,7 +293,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "5C3EB77537E1FA62"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -341,7 +337,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "1805FB9F3284DB60"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -361,7 +356,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "31DE6DB08C5E70BE"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -418,7 +412,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "75698ED44FA2B1F8"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -439,7 +432,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "789F5E46C45B0EB3"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -447,7 +439,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "6B9146F763943FE8"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -468,7 +459,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "183D87B447FBD8BB"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -521,7 +511,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "122F76B341A51635"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -581,7 +570,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "648F5FCF7685D6B0"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -637,7 +625,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "5A289B5F3E0313BF"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -731,7 +718,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7346B1D805621D89"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1002,7 +988,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "15459A42ED6498D9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1046,7 +1031,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "1EF64BA8385C9633"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1082,7 +1066,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6C7BFEA25666ABD1"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1126,7 +1109,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "6785C99A281DEC37"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1162,7 +1144,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "70EF1FE697ED75CB"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1182,7 +1163,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0C9548C7E92427CD"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1258,7 +1238,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "3D6BE8CBC0A1EB4E"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -1317,7 +1296,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "3E7B38F35C3CE978"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/thermal_series.snbt
+++ b/config/ftbquests/quests/chapters/thermal_series.snbt
@@ -68,7 +68,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0000000000000A7E"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -111,7 +110,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "00000000000004F0"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -149,7 +147,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "00000000000004EF"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -183,7 +180,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000004F2"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -205,7 +201,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004F4"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -227,7 +222,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004EE"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -250,7 +244,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "00000000000004F1"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -258,7 +251,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000A7F"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -287,7 +279,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "000000000000068B"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -315,7 +306,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "00000000000004F5"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -323,7 +313,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0F80388DC7F3BBE7"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -350,7 +339,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "000000000000064E"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -372,7 +360,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004FD"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -393,7 +380,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004FE"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -414,7 +400,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004FC"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -435,7 +420,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004FF"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -471,7 +455,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "00000000000004FB"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -516,7 +499,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "00000000000004FA"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -524,7 +506,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "21654D5CAA0CA9A2"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -575,7 +556,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "00000000000004F8"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -622,7 +602,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5839B6FFB471A35B"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -703,7 +682,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "26D4E44D620105C3"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -741,7 +719,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000FA0"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -749,7 +726,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "02D8D16DA88D3EAE"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -775,7 +751,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0000000000000FA1"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -783,7 +758,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "641575551F0A0BB3"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -810,7 +784,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "052C23B5160E5C9A"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -818,7 +791,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "4D495373F92BBBDE"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -845,7 +817,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5FF0D0F905311B5F"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -868,7 +839,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "7AE5586CD4CAE2A9"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -876,7 +846,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "3BF41840DB95F7F2"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -909,7 +878,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "0326C69AA6313AB5"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -954,7 +922,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 					icon: "kubejs:sorcerers_delight"
 					id: "74DFC2269FC7821A"
-					player_command: false
 					title: "Sorcerer's Delight"
 					type: "command"
 				}
@@ -962,7 +929,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "77BECFF6AF60992F"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -986,7 +952,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "662BB906D0FDBF13"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1017,7 +982,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "20A164BFA5B3D892"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1046,7 +1010,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0C85D800A09C7274"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1081,7 +1044,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0C38617502DA6408"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1089,7 +1051,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "3B1FC7BB9305BD04"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1123,7 +1084,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "1CCF6C81E9BB68D0"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1155,7 +1115,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "278E85C62D5EFE9C"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1190,7 +1149,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "28E0A1E3DFF37FD9"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1198,7 +1156,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "0BF32960907077A2"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1225,7 +1182,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "40630285BA554385"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1267,7 +1223,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "0BB4B9721715099A"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -1301,7 +1256,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "697A71208D8B0556"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1309,7 +1263,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "531F94AF73146444"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -1348,7 +1301,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "6755F22E361863C9"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1383,7 +1335,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "4F38DB2711B0BD4F"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1416,7 +1367,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5F8C36CD7F510840"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1442,7 +1392,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1F5AC36D1CD1F6BE"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1464,7 +1413,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "7384A73EC2DC63CD"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1490,7 +1438,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "2B1DC4A73AAEEC8E"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1524,7 +1471,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "577A44EBFEF00B0D"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1532,7 +1478,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "253ABFC880CD582B"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -1555,7 +1500,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "70598D1C5FFEC134"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1594,7 +1538,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000657"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1602,7 +1545,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "0000000000000865"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -1634,7 +1576,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000656"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1642,7 +1583,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 					icon: "kubejs:miners_delight"
 					id: "0000000000000866"
-					player_command: false
 					title: "Miner's Delight"
 					type: "command"
 				}
@@ -1673,7 +1613,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000659"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1745,7 +1684,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "0000000000000658"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1817,7 +1755,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "000000000000065A"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1840,7 +1777,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "0000000000000F9A"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1848,7 +1784,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0000000000000F9B"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -1871,7 +1806,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "43FC3062B765C50E"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1912,7 +1846,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "3ED3472B596C66F8"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1977,7 +1910,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "217C5B97521C7C27"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -2021,7 +1953,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "54AD1E646744806F"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -2029,7 +1960,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "682C30A4817B36A0"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/thermal_series_expert.snbt
+++ b/config/ftbquests/quests/chapters/thermal_series_expert.snbt
@@ -60,7 +60,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "6A5A5500DDD853A4"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -97,7 +96,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "3E31589A406DBA63"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -123,7 +121,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "517403840766CE9B"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -145,7 +142,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "5BBE973CF92A9780"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -168,7 +164,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "467638FBBBBA1129"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -176,7 +171,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "239A690985090125"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -205,7 +199,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "193EDF78A3E04D53"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -232,7 +225,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4210E54DDC394058"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -254,7 +246,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "23ABDE84C87F5211"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -275,7 +266,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "14971E1A5495EB6B"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -296,7 +286,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "51BC909489C10C92"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -317,7 +306,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "578306D91A22C541"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -353,7 +341,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "43F101BC77A8673B"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -398,7 +385,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "2A324B87D3B4F56D"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -406,7 +392,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "100656C2D1AFB4A9"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -457,7 +442,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "01AC3F6CE73D538E"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -504,7 +488,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "221872CEB5FA2D12"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -563,7 +546,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "2C91810C41B2D338"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -571,7 +553,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "4144491203F58E75"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -597,7 +578,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "29D6B666AEAC5267"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -605,7 +585,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "590E5DE244DFC01D"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -632,7 +611,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "778AEA217C7C8A2C"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -640,7 +618,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "1B476CCA9B8E06EB"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -667,7 +644,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "0774B29E91A76C00"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -690,7 +666,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "4AA02718DC4D5540"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -698,7 +673,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "4EE5F9B2065D91C7"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -725,7 +699,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "5AB560A303B8E2C9"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -757,7 +730,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "1C185A11F23DF778"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -765,7 +737,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "5CC3E27F1EC7040C"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -799,7 +770,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4BAEBA54F4FE9A0E"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -831,7 +801,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "2FC0A699D3902DD1"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -866,7 +835,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "7591C5EA445D189B"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -874,7 +842,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "0D033F01D1648B58"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}
@@ -920,7 +887,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "095F545D37921A44"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -954,7 +920,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "6FAAE1D7A1B0EF62"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -962,7 +927,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 					icon: "kubejs:farmers_delight"
 					id: "3590AC607FB5E76A"
-					player_command: false
 					title: "Farmer's Delight"
 					type: "command"
 				}
@@ -1001,7 +965,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "67C2F821185E408C"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1036,7 +999,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "7FD1EB8CA612CC76"
-					player_command: false
 					title: "Rare Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1069,7 +1031,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "368ACCCF678EEB95"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1095,7 +1056,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1A82EF559B0FEEC6"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1117,7 +1077,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 				icon: "kubejs:rare_lootbox"
 				id: "4AFCDF29F832CA61"
-				player_command: false
 				title: "Rare Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1143,7 +1102,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "2BDFD25054F99E1D"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1172,7 +1130,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "55810C2ED14BD748"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1210,7 +1167,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1EC0922E897E05ED"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1282,7 +1238,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "62823A34E4BDAC3E"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1354,7 +1309,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "1C648F07E6E0123D"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1377,7 +1331,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "1BA84461BB55E265"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1385,7 +1338,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "0B75D7FF01D5F371"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -1408,7 +1360,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/farmers_delight"
 				icon: "kubejs:farmers_delight"
 				id: "663D39875F054628"
-				player_command: false
 				title: "Farmer's Delight"
 				type: "command"
 			}]
@@ -1449,7 +1400,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 				icon: "kubejs:epic_lootbox"
 				id: "75FB2CB390074E86"
-				player_command: false
 				title: "Epic Thermal Series Loot Box"
 				type: "command"
 			}]
@@ -1514,7 +1464,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/miners_delight"
 				icon: "kubejs:miners_delight"
 				id: "3C93FC3B56BDC758"
-				player_command: false
 				title: "Miner's Delight"
 				type: "command"
 			}]
@@ -1558,7 +1507,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/epic"
 					icon: "kubejs:epic_lootbox"
 					id: "537C61EA3760C79B"
-					player_command: false
 					title: "Epic Thermal Series Loot Box"
 					type: "command"
 				}
@@ -1566,7 +1514,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/alchemists_delight"
 					icon: "kubejs:alchemists_delight"
 					id: "76EBD00E27FA6F5B"
-					player_command: false
 					title: "Alchemist's Delight"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/tools.snbt
+++ b/config/ftbquests/quests/chapters/tools.snbt
@@ -156,7 +156,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "43188DFF0C8F9DDC"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -182,7 +181,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "4FDD99B9F9F65B1D"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -230,7 +228,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "64504DDDBC9AC25E"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}
@@ -392,7 +389,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "3748DAA3600EA73A"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -449,7 +445,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "418FF73BC209465E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -746,7 +741,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "39E9528BE6DAB579"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -900,7 +894,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "249BCC9ECEB1E87E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -959,7 +952,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "49EF6BF284B65CD2"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1062,7 +1054,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "451D4EF8E99423F4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1243,7 +1234,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4734ACE72F894A6E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/tools_expert.snbt
+++ b/config/ftbquests/quests/chapters/tools_expert.snbt
@@ -156,7 +156,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7B241F0433CB46B4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -182,7 +181,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "7878D3C0A8B1AE6D"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -387,7 +385,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "0074A49DCD3DD188"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -425,7 +422,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "3570B6A36168655F"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -723,7 +719,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
 				icon: "kubejs:sorcerers_delight"
 				id: "26D391BE317C1493"
-				player_command: false
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
@@ -862,7 +857,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "52510292FF8D040C"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -1115,7 +1109,6 @@
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 					icon: "kubejs:scavengers_delight"
 					id: "2FCA3B2C9ABB9D73"
-					player_command: false
 					title: "Scavenger's Delight"
 					type: "command"
 				}

--- a/config/ftbquests/quests/chapters/villagers.snbt
+++ b/config/ftbquests/quests/chapters/villagers.snbt
@@ -16,7 +16,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "647F0610EA3206AD"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -37,7 +36,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7D551D76A1C3C105"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -58,7 +56,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "067359D0E85D8EAC"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -79,7 +76,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6E3D8216B0D43FAB"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -100,7 +96,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "57A4C718E9577EF9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -121,7 +116,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4267FF60EA57321D"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -142,7 +136,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2B45A46D7A9BB397"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -163,7 +156,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4A36446F83198A3E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -207,7 +199,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "53258046C5E506CF"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -228,7 +219,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "26F83CEFA1D37BA4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -249,7 +239,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "17C25CFD5C10A9AF"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -270,7 +259,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "56C09E74F4C04953"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -291,7 +279,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4392DF4D0E221A53"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -312,7 +299,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6BC33728C5D8D0D8"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -333,7 +319,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "316A4A9FFCA2A234"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -354,7 +339,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "1A3C78B0ED00AA55"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -375,7 +359,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "24D908FD3162B3A4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -396,7 +379,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "374E53F3C57E58EF"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -417,7 +399,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5E267462A0C76C1A"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -438,7 +419,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0FFCBB51F1110EA5"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -459,7 +439,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "1537AFD0D27EB5C7"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -485,7 +464,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "1D2310A4FC9D436D"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]

--- a/config/ftbquests/quests/chapters/villagers_expert.snbt
+++ b/config/ftbquests/quests/chapters/villagers_expert.snbt
@@ -16,7 +16,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0C95B6DC07AD0BE9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -37,7 +36,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5CC67A2426602997"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -58,7 +56,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "03E298EA8E6067CD"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -79,7 +76,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2A6758B68600AC1F"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -100,7 +96,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "394BB50E84096B55"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -121,7 +116,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6236F2A8BC341526"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -142,7 +136,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "470AF5F4392838E4"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -163,7 +156,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "511EDDF455805A19"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -207,7 +199,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2C6369052E2F9461"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -228,7 +219,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6886A183E6C3283E"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -249,7 +239,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "0538883C54775B33"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -270,7 +259,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "7EF42B6A98D6340B"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -291,7 +279,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5B2649A6081434D9"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -312,7 +299,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4A7C2F412652EE4C"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -333,7 +319,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "6579CF88E0968397"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -354,7 +339,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "4C9C4580BCF7757B"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -375,7 +359,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5259D49C49DAB5DF"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -396,7 +379,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "186F59EBEABC7E7C"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -417,7 +399,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "2E3163DF1860C162"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -438,7 +419,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "5C7BB752EC3632BB"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]
@@ -464,7 +444,6 @@
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
 				icon: "kubejs:scavengers_delight"
 				id: "59EE246084CF7CDB"
-				player_command: false
 				title: "Scavenger's Delight"
 				type: "command"
 			}]


### PR DESCRIPTION
Recent ftbquests update appears to have removed some default values from most quests. 
Also fixes ch3 expert quest erroneously calling for blitz instead of blizz