### PR TITLE
Expert Recipes for newish items

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Enigmatica 9 v1.16.0
+
+### 🌟 Improvements
+
+-   Moved Spell Sensors and Spell Mirrors to early game [\#735](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/735)
+-   Added compat for Thermal's Rubberwood [\#735](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/735)
+-   Disabled Thermal's Energy Cart [\#735](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/735)
+
 ### Enigmatica 9 v1.15.0
 
 ### 🎁 New Mods Added

--- a/kubejs/client_scripts/constants/jei_hidden_disabled.js
+++ b/kubejs/client_scripts/constants/jei_hidden_disabled.js
@@ -712,6 +712,7 @@ jei.expert.items.disabled = [
     'thermal:energy_limiter_attachment',
     'thermal:energy_duct',
     'thermal:machine_insolator',
+    'thermal:energy_minecart',
 
     'twilightforest:candelabra',
     'twilightforest:keepsake_casket',

--- a/kubejs/data/farmingforblockheads/farmingforblockheads_compat/saplings_for_emeralds.json
+++ b/kubejs/data/farmingforblockheads/farmingforblockheads_compat/saplings_for_emeralds.json
@@ -13,6 +13,7 @@
         { "output": "twilightforest:mangrove_sapling" },
         { "output": "twilightforest:canopy_sapling" },
         { "output": "twilightforest:twilight_oak_sapling" },
+        { "output": "thermal:rubberwood_sapling" },
         { "output": "byg:yellow_spruce_sapling" },
         { "output": "byg:yellow_birch_sapling" },
         { "output": "byg:red_spruce_sapling" },

--- a/kubejs/server_scripts/base/recipes/thermal/tree_extractor.js
+++ b/kubejs/server_scripts/base/recipes/thermal/tree_extractor.js
@@ -7,6 +7,12 @@ ServerEvents.recipes((event) => {
             leaves: 'minecraft:jungle_leaves',
             result: { fluid: 'industrialforegoing:latex', amount: 25 },
             id: 'thermal:devices/tree_extractor/tree_extractor_jungle'
+        },
+        {
+            trunk: 'thermal:rubberwood_log',
+            leaves: 'thermal:rubberwood_leaves',
+            result: { fluid: 'industrialforegoing:latex', amount: 75 },
+            id: 'thermal:devices/tree_extractor/tree_extractor_rubberwood'
         }
     ];
 

--- a/kubejs/server_scripts/constants/tree_properties.js
+++ b/kubejs/server_scripts/constants/tree_properties.js
@@ -993,6 +993,18 @@ const tree_properties = {
                 sap: 'thermal:resin',
                 rate: { living: 50, dead: 6 }
             }
+        },
+        // Thermal Series
+        {
+            sapling: 'thermal:rubberwood_sapling',
+            stems: ['thermal:rubberwood_log'],
+            foliage: ['thermal:rubberwood_leaves'],
+            dimension: 'overworld',
+            substrate: 'dirt',
+            logProcessing: {
+                sap: 'industrialforegoing:latex',
+                rate: { living: 150, dead: 18 }
+            }
         }
     ],
     shrooms: [

--- a/kubejs/server_scripts/constants/wood_properties.js
+++ b/kubejs/server_scripts/constants/wood_properties.js
@@ -57,6 +57,7 @@ var wood_variants_constructor = [
     'quark:azalea',
     'quark:blossom',
     'quark:ancient',
+    'thermal:rubberwood',
     'twilightforest:twilight_oak',
     'twilightforest:canopy',
     'twilightforest:mangrove',

--- a/kubejs/server_scripts/expert/recipes/ars_elemental/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ars_elemental/shaped.js
@@ -24,6 +24,17 @@ ServerEvents.recipes((event) => {
                 C: '#forge:gems/source'
             },
             id: 'ars_elemental:caster_bag'
+        },
+        {
+            output: 'ars_elemental:spell_mirror',
+            pattern: [' A ', 'BCB', 'DA '],
+            key: {
+                A: '#forge:ingots/gold',
+                B: '#forge:wires/electrum',
+                C: '#forge:gems/source',
+                D: '#forge:essences/air'
+            },
+            id: `${id_prefix}spell_mirror`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/patchouli_safe_remove.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/patchouli_safe_remove.js
@@ -37,7 +37,8 @@ ServerEvents.recipes((event) => {
             { id: 'ars_nouveau:summon_focus', output: 'ars_nouveau:summon_focus' },
             { id: 'ars_nouveau:shapers_focus', output: 'ars_nouveau:shapers_focus' },
             { id: 'ars_nouveau:relay_splitter', output: 'ars_nouveau:relay_splitter' },
-            { id: 'ars_nouveau:spell_sensor', output: 'ars_nouveau:spell_sensor' }
+            { id: 'ars_nouveau:spell_sensor', output: 'ars_nouveau:spell_sensor' },
+            { id: 'ars_elemental:spell_mirror', output: 'ars_elemental:spell_mirror' }
         ],
         imbuement: [
             { id: 'ars_nouveau:imbuement_lapis', output: 'emendatusenigmatica:source_gem' },

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/patchouli_safe_remove.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/patchouli_safe_remove.js
@@ -36,7 +36,8 @@ ServerEvents.recipes((event) => {
             { id: 'ars_elemental:necrotic_focus', output: 'ars_elemental:necrotic_focus' },
             { id: 'ars_nouveau:summon_focus', output: 'ars_nouveau:summon_focus' },
             { id: 'ars_nouveau:shapers_focus', output: 'ars_nouveau:shapers_focus' },
-            { id: 'ars_nouveau:relay_splitter', output: 'ars_nouveau:relay_splitter' }
+            { id: 'ars_nouveau:relay_splitter', output: 'ars_nouveau:relay_splitter' },
+            { id: 'ars_nouveau:spell_sensor', output: 'ars_nouveau:spell_sensor' }
         ],
         imbuement: [
             { id: 'ars_nouveau:imbuement_lapis', output: 'emendatusenigmatica:source_gem' },

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/shaped.js
@@ -177,6 +177,16 @@ ServerEvents.recipes((event) => {
                 D: 'ae2:charged_certus_quartz_crystal'
             },
             id: `${id_prefix}relay_splitter`
+        },
+        {
+            output: 'ars_nouveau:spell_sensor',
+            pattern: ['ABA', 'BCB', 'ABA'],
+            key: {
+                A: '#forge:ingots/gold',
+                B: '#forge:planks/archwood',
+                C: 'glassential:glass_redstone'
+            },
+            id: `${id_prefix}spell_sensor`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -548,6 +548,7 @@ ServerEvents.recipes((event) => {
         { id: 'thermal:machines/pulverizer/pulverizer_diamond' },
         { id: 'thermal:machines/crucible/crucible_ender_pearl' },
         { id: 'thermal:fuels/disenchantment/disenchantment_experience_bottle' },
+        { id: 'thermal:energy_minecart' },
 
         { id: /theurgy:.*divination_rod/ },
 

--- a/kubejs/server_scripts/expert/recipes/thermal/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/shaped.js
@@ -481,6 +481,18 @@ ServerEvents.recipes((event) => {
                 C: '#forge:nuggets/lead'
             },
             id: `${id_prefix}explosive_grenade`
+        },
+        {
+            output: 'thermal:device_xp_condenser',
+            pattern: ['ABA', 'CDC', 'AEA'],
+            key: {
+                A: '#forge:nuggets/electrum',
+                B: '#forge:gears/silver',
+                C: 'thermal:xp_crystal',
+                D: 'ars_nouveau:blue_archwood_log',
+                E: 'thermal:redstone_servo'
+            },
+            id: 'thermal:device_xp_condenser'
         }
     ];
 


### PR DESCRIPTION
Move Spell Sensor and Spell Mirror to early game
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/3d80ea11-463c-45df-b3f9-d2c5f7c3a887)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/8f44b0c0-1516-4d11-8101-7424fdf37997)

Thermal Rubberwood may now be used for latex and can be processed by machines for planks. 

Disabled Thermal energy cart. 


