### PR TITLE
General improvements

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Glowstone blocks may now be crushed by Ars Nouveau Crush Glyph [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
 -   Minor tweaks to quest dependencies to create a better flow [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
+-   Environmental Eye is now an early quest reward [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
 
 ---
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -6,6 +6,10 @@
 -   Minor tweaks to quest dependencies to create a better flow [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
 -   Environmental Eye is now an early quest reward [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
 
+### 🐛 Fixed Bugs
+
+-   [Expert] Set Default Exit Dim for BumbleZone to Twilight Forest [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
+
 ---
 
 ### Enigmatica 9 v1.15.1

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,3 +1,12 @@
+### Enigmatica 9 v1.16.0
+
+### 🌟 Improvements
+
+-   Glowstone blocks may now be crushed by Ars Nouveau Crush Glyph [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
+-   Minor tweaks to quest dependencies to create a better flow [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
+
+---
+
 ### Enigmatica 9 v1.15.1
 
 🚀 Forge-1.19.2-43.2.14 | [📜 Mod Updates](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/changelog_mods_1.15.1.md) | [📋 Modlist](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/modlist_1.15.1.md)

--- a/config/configswapper/expert/config/the_bumblezone/dimension.toml
+++ b/config/configswapper/expert/config/the_bumblezone/dimension.toml
@@ -1,0 +1,94 @@
+
+["The Bumblezone Dimension Options"]
+	# 
+	#-----------------------------------------------------
+	#
+	# How bright the fog is in the Bumblezone dimension. 
+	# 
+	# The brightness is represented as a percentage
+	# so 0 will be pitch black, 50 will be half
+	# as bright, 100 will be normal orange brightness,
+	# and 100000 will be white.
+	#
+	#Range: 0.0 ~ 100000.0
+	fogBrightnessPercentage = 100.0
+	# 
+	#-----------------------------------------------------
+	#
+	# Whether Bumblezone dimension has thick fog or not.
+	#
+	enableDimensionFog = true
+	# 
+	#-----------------------------------------------------
+	#
+	# How thick the fog in Bumblezone is.
+	# 2 is a little bit of fog and 50 is super thick fog. Decimal values are allowed.
+	#
+	#Range: 0.0 ~ 100.0
+	fogThickness = 4.0
+
+["The Bumblezone Teleportation Options"]
+	# 
+	#-----------------------------------------------------
+	#
+	# Allow Bumblezone mod to handle teleporting into the Bumblezone dimension.
+	#
+	enableEntranceTeleportation = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Allow Bumblezone mod to handle teleporting out of the Bumblezone dimension.
+	#
+	enableExitTeleportation = true
+	# 
+	#-----------------------------------------------------
+	#
+	# If this is enabled, mobs that originally spawned in Bumblezone will be teleported
+	# to 0, 0 center of the Overworld when exiting Bumblezone dimension.
+	#
+	forceBumblezoneOriginMobToOverworldCenter = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Makes leaving The Bumblezone dimension always places you back
+	# at the Overworld regardless of which dimension you originally 
+	# came from. Use this option if this dimension becomes locked in  
+	# with another dimension so you are stuck teleporting between the 
+	# two and cannot get back to the Overworld.
+	#
+	forceExitToOverworld = false
+	# 
+	#-----------------------------------------------------
+	#
+	# Makes throwing Enderpearls at Bee Nests or Hives only 
+	# work in the Overworld. What this means setting this to true makes it 
+	# only possible to enter The Bumblezone dimension from the Overworld
+	onlyOverworldHivesTeleports = false
+	# 
+	#-----------------------------------------------------
+	#
+	# If the block tag the_bumblezone:dimension_teleportation/required_blocks_under_beehive_to_teleport
+	# has blocks specified and this config is set to true, then player will get a warning if they
+	# throw an Enderpearl at a Bee Nest/Beehive but the block under it is 
+	# not the correct required block. It will also tell the player what 
+	# block is needed under the Bee Nest/Beehive to teleport to the dimension.
+	#
+	warnPlayersOfWrongBlockUnderHive = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Should teleporting to and from The Bumblezone work 
+	# with modded Bee Nests and modded Beehives as well. 
+	#
+	allowTeleportationWithModdedBeehives = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Changes the default dimension that teleporting exiting will take mobs to 
+	# if there is no previously saved dimension on the mob. 
+	# Use this option ONLY if your modpack's default dimension is not the Overworld. 
+	# This will affect forceExitToOverworld, forceBumblezoneOriginMobToOverworldCenter, and onlyOverworldHivesTeleports
+	# config options so that they use this new default dimension instead of overworld.
+	#
+	defaultDimension = "twilightforest:twilight_forest"
+

--- a/config/configswapper/normal/config/the_bumblezone/dimension.toml
+++ b/config/configswapper/normal/config/the_bumblezone/dimension.toml
@@ -1,0 +1,94 @@
+
+["The Bumblezone Dimension Options"]
+	# 
+	#-----------------------------------------------------
+	#
+	# How bright the fog is in the Bumblezone dimension. 
+	# 
+	# The brightness is represented as a percentage
+	# so 0 will be pitch black, 50 will be half
+	# as bright, 100 will be normal orange brightness,
+	# and 100000 will be white.
+	#
+	#Range: 0.0 ~ 100000.0
+	fogBrightnessPercentage = 100.0
+	# 
+	#-----------------------------------------------------
+	#
+	# Whether Bumblezone dimension has thick fog or not.
+	#
+	enableDimensionFog = true
+	# 
+	#-----------------------------------------------------
+	#
+	# How thick the fog in Bumblezone is.
+	# 2 is a little bit of fog and 50 is super thick fog. Decimal values are allowed.
+	#
+	#Range: 0.0 ~ 100.0
+	fogThickness = 4.0
+
+["The Bumblezone Teleportation Options"]
+	# 
+	#-----------------------------------------------------
+	#
+	# Allow Bumblezone mod to handle teleporting into the Bumblezone dimension.
+	#
+	enableEntranceTeleportation = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Allow Bumblezone mod to handle teleporting out of the Bumblezone dimension.
+	#
+	enableExitTeleportation = true
+	# 
+	#-----------------------------------------------------
+	#
+	# If this is enabled, mobs that originally spawned in Bumblezone will be teleported
+	# to 0, 0 center of the Overworld when exiting Bumblezone dimension.
+	#
+	forceBumblezoneOriginMobToOverworldCenter = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Makes leaving The Bumblezone dimension always places you back
+	# at the Overworld regardless of which dimension you originally 
+	# came from. Use this option if this dimension becomes locked in  
+	# with another dimension so you are stuck teleporting between the 
+	# two and cannot get back to the Overworld.
+	#
+	forceExitToOverworld = false
+	# 
+	#-----------------------------------------------------
+	#
+	# Makes throwing Enderpearls at Bee Nests or Hives only 
+	# work in the Overworld. What this means setting this to true makes it 
+	# only possible to enter The Bumblezone dimension from the Overworld
+	onlyOverworldHivesTeleports = false
+	# 
+	#-----------------------------------------------------
+	#
+	# If the block tag the_bumblezone:dimension_teleportation/required_blocks_under_beehive_to_teleport
+	# has blocks specified and this config is set to true, then player will get a warning if they
+	# throw an Enderpearl at a Bee Nest/Beehive but the block under it is 
+	# not the correct required block. It will also tell the player what 
+	# block is needed under the Bee Nest/Beehive to teleport to the dimension.
+	#
+	warnPlayersOfWrongBlockUnderHive = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Should teleporting to and from The Bumblezone work 
+	# with modded Bee Nests and modded Beehives as well. 
+	#
+	allowTeleportationWithModdedBeehives = true
+	# 
+	#-----------------------------------------------------
+	#
+	# Changes the default dimension that teleporting exiting will take mobs to 
+	# if there is no previously saved dimension on the mob. 
+	# Use this option ONLY if your modpack's default dimension is not the Overworld. 
+	# This will affect forceExitToOverworld, forceBumblezoneOriginMobToOverworldCenter, and onlyOverworldHivesTeleports
+	# config options so that they use this new default dimension instead of overworld.
+	#
+	defaultDimension = "minecraft:overworld"
+

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -52,7 +52,7 @@
 				}
 			]
 			title: "Basic Metallurgy"
-			x: -0.5d
+			x: -2.5d
 			y: -7.5d
 		}
 		{
@@ -527,8 +527,8 @@
 					type: "item"
 				}
 			]
-			x: -1.5d
-			y: 1.0d
+			x: -3.5d
+			y: 0.5d
 		}
 		{
 			dependencies: [
@@ -825,6 +825,7 @@
 				""
 				"Discover the rest of the process through JEI."
 			]
+			hide_dependency_lines: true
 			icon: "immersiveengineering:ingot_aluminum"
 			id: "345CBD118EAA0C09"
 			rewards: [{
@@ -852,8 +853,8 @@
 					type: "item"
 				}
 			]
-			x: -2.0d
-			y: 2.0d
+			x: -1.5d
+			y: -2.5d
 		}
 		{
 			dependencies: ["73CDA6ED2393DE42"]
@@ -1175,7 +1176,7 @@
 				type: "item"
 			}]
 			x: -3.5d
-			y: 1.0d
+			y: 2.0d
 		}
 		{
 			dependencies: ["66585A158F41DE44"]
@@ -1266,16 +1267,40 @@
 		{
 			dependencies: ["79B755D0BDB6A8B7"]
 			description: [
-				"More finely crafted apparatus will need more delicately formed metals."
+				"More finely crafted devices will need more delicately processed materials than can easily be done by hand."
 				""
-				"These tough mechanical machines, the Mechanical Press and Rolling Mill, are up to the task of properly pounding out plates or forming wires and rods, respectively. "
+				"These tough mechanical devices are up to the task. "
+				""
+				"● Millstone - Capable of grinding "
+				"  materials much more finely than can "
+				"  be achieved by hand, the Millstone will "
+				"  occasionally produce secondary       "
+				"  materials that may be quite useful, "
+				"  such as Lead and Quartz."
+				""
+				"● Rolling Mill - Working from Ingots, the "
+				"  Rolling Mill can create the fine Rods "
+				"  and Wires required by many "
+				"  advanced devices. "
+				""
+				"● Mechanical Press - A device strong "
+				"  enough to flatten Ingots into Plates "
+				"  in only a few strokes. Well worth the "
+				"  effort of setting it up.  "
 			]
 			id: "44B02A5817C4144A"
-			rewards: [{
-				id: "0FC05A9E5B974922"
-				item: "ars_creo:starbuncle_wheel"
-				type: "item"
-			}]
+			rewards: [
+				{
+					id: "0FC05A9E5B974922"
+					item: "ars_creo:starbuncle_wheel"
+					type: "item"
+				}
+				{
+					id: "36C648094A71AC39"
+					item: "createaddition:straw"
+					type: "item"
+				}
+			]
 			tasks: [
 				{
 					id: "7E269B72F57C62D3"
@@ -1285,6 +1310,11 @@
 				{
 					id: "1A61D7D0519A6615"
 					item: "createaddition:rolling_mill"
+					type: "item"
+				}
+				{
+					id: "00BD1D8A00CAB755"
+					item: "create:millstone"
 					type: "item"
 				}
 			]
@@ -1354,7 +1384,7 @@
 					type: "item"
 				}
 			]
-			x: -0.5d
+			x: -2.5d
 			y: -6.5d
 		}
 		{
@@ -1389,7 +1419,7 @@
 				title: "Alloying"
 				type: "item"
 			}]
-			x: -0.5d
+			x: -2.5d
 			y: -5.5d
 		}
 		{
@@ -1800,53 +1830,7 @@
 			]
 			title: "Tree of Life"
 			x: -3.5d
-			y: 2.0d
-		}
-		{
-			dependencies: ["347A644441BCF449"]
-			description: ["Often found clustered in with Tin ores, Quartz may be extracted occasionally when grinding the ore with better tools, such as the Mill. "]
-			id: "5B7806FED7D58329"
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
-				icon: "kubejs:scavengers_delight"
-				id: "2D22DA949427C0B4"
-				title: "Scavenger's Delight"
-				type: "command"
-			}]
-			tasks: [{
-				id: "76702DE4AA5CCE26"
-				item: "minecraft:quartz"
-				type: "item"
-			}]
-			x: -6.0d
-			y: 2.5d
-		}
-		{
-			dependencies: ["79B755D0BDB6A8B7"]
-			description: ["Made from considerably tougher materials than a simple Mortar, the Millstone can grind tougher ores and may even occasionally recover some secondary materials.  "]
-			hide_dependency_lines: true
-			id: "347A644441BCF449"
-			rewards: [
-				{
-					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
-					icon: "kubejs:sorcerers_delight"
-					id: "651C07D976AD902F"
-					title: "Sorcerer's Delight"
-					type: "command"
-				}
-				{
-					id: "0E1F9854A317EE27"
-					item: "createaddition:straw"
-					type: "item"
-				}
-			]
-			tasks: [{
-				id: "0F473BC094DDA58D"
-				item: "create:millstone"
-				type: "item"
-			}]
-			x: -5.0d
-			y: 2.0d
+			y: 3.0d
 		}
 		{
 			dependencies: ["3A7AEB067C49F899"]
@@ -2516,18 +2500,18 @@
 				}
 				type: "item"
 			}]
+			shape: "hexagon"
 			tasks: [{
 				id: "3716441EC6ACD043"
 				item: "ars_nouveau:basic_spell_turret"
 				type: "item"
 			}]
-			x: -5.5d
-			y: 1.0d
+			x: 2.5d
+			y: -2.0d
 		}
 		{
-			dependencies: ["729E9D41A28D0E4D"]
+			dependencies: ["345CBD118EAA0C09"]
 			description: ["An empowered ritual that grants an hour of flight to up to five entities. Useful for exploration far from home. Be sure to bring the materials to re-cast it if necessary. "]
-			hide_dependency_lines: true
 			icon: "ars_nouveau:ritual_flight"
 			id: "6952D7AD61181E37"
 			rewards: [{
@@ -2552,7 +2536,7 @@
 				}
 			]
 			x: -1.0d
-			y: 2.5d
+			y: -1.0d
 		}
 		{
 			dependencies: ["1C6BF5FE58C49456"]

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -217,6 +217,11 @@
 					type: "item"
 				}
 				{
+					id: "4C7C143A9FAD1DF6"
+					item: "naturesaura:eye"
+					type: "item"
+				}
+				{
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/aura_leaves/tiny"
 					icon: "kubejs:aura_leaf"
 					id: "39B68CC0E19837B6"

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -1813,8 +1813,8 @@
 				item: "minecraft:quartz"
 				type: "item"
 			}]
-			x: -5.0d
-			y: 2.0d
+			x: -6.0d
+			y: 2.5d
 		}
 		{
 			dependencies: ["79B755D0BDB6A8B7"]
@@ -1840,8 +1840,8 @@
 				item: "create:millstone"
 				type: "item"
 			}]
-			x: -5.5d
-			y: 1.0d
+			x: -5.0d
+			y: 2.0d
 		}
 		{
 			dependencies: ["3A7AEB067C49F899"]
@@ -2456,7 +2456,7 @@
 			y: 2.0d
 		}
 		{
-			dependencies: ["729E9D41A28D0E4D"]
+			dependencies: ["16E90BC107468EC2"]
 			description: [
 				"With heightened spell casting ability comes the ability to improve some automation through Spell Turrets.  "
 				""
@@ -2511,14 +2511,13 @@
 				}
 				type: "item"
 			}]
-			shape: "hexagon"
 			tasks: [{
 				id: "3716441EC6ACD043"
 				item: "ars_nouveau:basic_spell_turret"
 				type: "item"
 			}]
-			x: -6.0d
-			y: 2.5d
+			x: -5.5d
+			y: 1.0d
 		}
 		{
 			dependencies: ["729E9D41A28D0E4D"]

--- a/kubejs/server_scripts/base/recipes/ars_nouveau/crushing.js
+++ b/kubejs/server_scripts/base/recipes/ars_nouveau/crushing.js
@@ -63,7 +63,6 @@ ServerEvents.recipes((event) => {
             input: 'ae2:sky_stone_block',
             id: `${id_prefix}sky_dust`
         },
-
         {
             output: [
                 { item: 'create:wheat_flour', count: 1, chance: 1.0 },
@@ -72,6 +71,11 @@ ServerEvents.recipes((event) => {
             ],
             input: '#forge:crops/wheat',
             id: `${id_prefix}wheat_flour`
+        },
+        {
+            output: [{ item: 'minecraft:glowstone_dust', count: 4, chance: 1.0 }],
+            input: '#forge:storage_blocks/glowstone',
+            id: `${id_prefix}glowstone`
         }
     ];
 


### PR DESCRIPTION
- Glowstone blocks may now be crushed by Ars Nouveau Crush Glyph
- Minor tweaks to quest dependencies to create a better flow 
- Environmental Eye is now an early quest reward
- [Expert] Set Default Exit Dim for BumbleZone to Twilight Forest, partially fixing https://github.com/EnigmaticaModpacks/Enigmatica9/issues/742