### PR TITLE
Brewing fixes

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Low Aura will no longer cause explosions [\#748](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/748)
 -   Upgrading Potions of Knowledge to the level two version now uses Glowstone Dust similar to all other potions [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 -   [Expert] Awkward potions are no longer brewable with Netherwart to promote the use of the far easier to obtain Abjuration Essence [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
+-   [Expert] Nether Wart may now be used to make Ethanol more efficiently [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 -   [Expert] The Break Glyph no longer requires Iron, making it accessible closer to when a Tier 2 book is available [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 
 ### 🐛 Fixed Bugs

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -6,11 +6,13 @@
 -   Minor tweaks to quest dependencies to create a better flow [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
 -   Environmental Eye is now an early quest reward [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
 -   Low Aura will no longer cause explosions [\#748](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/748)
+-   Upgrading Potions of Knowledge to the level two version now uses Glowstone Dust similar to all other potions [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
+-   [Expert] Awkward potions are no longer brewable with Netherwart to promote the use of the far easier to obtain Abjuration Essence [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 
 ### 🐛 Fixed Bugs
 
 -   [Expert] Set Default Exit Dim for BumbleZone to Twilight Forest [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
--   XP Melting now requires Superheating in Create to avoid a conflict with potion brewing [\#748](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/748)
+-   XP Melting now requires Superheating in Create to avoid a conflict with potion brewing [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 
 ---
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   [Expert] Awkward potions are no longer brewable with Netherwart to promote the use of the far easier to obtain Abjuration Essence [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 -   [Expert] Nether Wart may now be used to make Ethanol more efficiently [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 -   [Expert] The Break Glyph no longer requires Iron, making it accessible closer to when a Tier 2 book is available [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
+-   [Expert] Soul Powder quest has been updated to help clarify that it can be mined in the Twilight Forest too [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🐛 Fixed Bugs
 
 -   [Expert] Set Default Exit Dim for BumbleZone to Twilight Forest [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
+-   XP Melting now requires Superheating in Create to avoid a conflict with potion brewing [\#748](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/748)
 
 ---
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Low Aura will no longer cause explosions [\#748](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/748)
 -   Upgrading Potions of Knowledge to the level two version now uses Glowstone Dust similar to all other potions [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 -   [Expert] Awkward potions are no longer brewable with Netherwart to promote the use of the far easier to obtain Abjuration Essence [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
+-   [Expert] The Break Glyph no longer requires Iron, making it accessible closer to when a Tier 2 book is available [\#751](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/751)
 
 ### 🐛 Fixed Bugs
 

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -1160,6 +1160,10 @@
 				"With the elements mastered, only one task remains before the Tree of Life may be restored: Winter’s Reign must end. "
 				""
 				"Travel to the frigid glaciers and defeat the Snow Queen to obtain Subzero Crystals."
+				""
+				"================================="
+				""
+				"Through the natural transmutation magics imbued in a Botanist’s Pickaxe, it should be possible to purify the Subzero Crystal and induce it to grow. "
 			]
 			hide_dependency_lines: true
 			id: "729E9D41A28D0E4D"
@@ -1951,7 +1955,7 @@
 				""
 				"Begin by locating some Certus Quartz; the Wilden Grove will undoubtedly have left some behind in their ore mounds. "
 				""
-				"Through the natural transmutation magics imbued in a Botanist’s Pickaxe, it should be possible to purify the quartz and induce it to grow. "
+				"Through the natural transmutation magics imbued in a Botanist’s Pickaxe, it should be possible to purify the Certus Quartz and induce it to grow. "
 			]
 			hide_dependency_lines: true
 			id: "0BAE6EBFEA3026B9"
@@ -2325,6 +2329,8 @@
 				"================================="
 				""
 				"Obtain Wool of each color and provide it to the Ram. "
+				""
+				"Through the natural transmutation magics imbued in a Botanist’s Pickaxe, it should be possible to purify the Therium and induce it to grow. "
 			]
 			id: "032D29DD7D946EDB"
 			rewards: [

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -1474,7 +1474,7 @@
 				""
 				"To let the Wixie know what potions to brew, place some brewed potions on Arcane Pedestals or Platforms adjacent to her Cauldron. These can be obtained by brewing in the Mixing Cauldron and Right-Clicking it with Glass Bottles. "
 				""
-				"The entire chain must be present for her to do her job. So, to brew a Potion of Ancient Knowledge, she’ll need a pedestal with an Awkward Potion and another with a Potion of Ancient Knowledge. She’ll need a Potion Jar for each step as well. Multiple Wixies may work together as well, with each fulfilling the next step in the chain. "
+				"The entire chain must be present for her to do her job. So, to brew a Potion of Ancient Knowledge, she’ll need a pedestal with an Awkward Potion and another with a Potion of Ancient Knowledge. She’ll need a Potion Jar for each step as well. Multiple Wixies may work together, with each fulfilling the next step in the chain. "
 				""
 				"More information can be found in the Worn Notebook. "
 			]
@@ -2212,8 +2212,8 @@
 				title: "Tipped Arrows"
 				type: "item"
 			}]
-			x: 2.0d
-			y: -3.0d
+			x: 1.5d
+			y: -2.0d
 		}
 		{
 			dependencies: ["4682D4537535937C"]
@@ -2243,7 +2243,9 @@
 		{
 			dependencies: ["370C40BCC3A6A055"]
 			description: [
-				"Ordinarily Crush may only be used on blocks placed in the world. For example, for creating Compressed Stone. However, by augmenting it with Sensitive, it can target items dropped on the ground as well allowing it to function on Raw Ore as well."
+				"Ordinarily Crush may only be used on blocks placed in the world. For example, when creating Compressed Stone. "
+				""
+				"However, by augmenting it with Sensitive, it can target items dropped on the ground as well allowing it to function on Raw Ore as well."
 				""
 				"The following spell form will crush items on the ground: "
 				""

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -883,7 +883,9 @@
 			description: [
 				"Though many glyphs may be found and used to repair the spell book, the Scribe’s Table may also be used to craft any glyph. "
 				""
-				"Finding proper spell ink, however, may prove more difficult as it must be specially prepared using a process that can take years."
+				"Finding proper spell ink, however, may prove more difficult as it must be specially prepared using a process that can take years. "
+				""
+				"It was once heavily traded by the seafaring folk that specialized in its creation. Perhaps some could be retrieved with some good old-fashioned trawling. "
 			]
 			id: "7507572BD048B6C9"
 			rewards: [{

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -2243,7 +2243,7 @@
 		{
 			dependencies: ["370C40BCC3A6A055"]
 			description: [
-				"Ordinarily Crush may only be used on blocks placed in the world. However, by augmenting it with Sensitive, it can target items dropped on the ground as well. "
+				"Ordinarily Crush may only be used on blocks placed in the world. For example, for creating Compressed Stone. However, by augmenting it with Sensitive, it can target items dropped on the ground as well allowing it to function on Raw Ore as well."
 				""
 				"The following spell form will crush items on the ground: "
 				""

--- a/config/ftbquests/quests/chapters/chapter_three.snbt
+++ b/config/ftbquests/quests/chapters/chapter_three.snbt
@@ -71,7 +71,7 @@
 			description: [
 				"Refined from Sculk, this mineral is associated with primal chaos. "
 				""
-				"Normally exceptionally rare, the ancients of this land appear to have been harvesting it for unknown ends. "
+				"Normally exceptionally rare, the ancients of this land appear to have been harvesting it for unknown purposes. "
 			]
 			id: "714A42E9CE3C32EA"
 			rewards: [{
@@ -848,7 +848,11 @@
 		}
 		{
 			dependencies: ["17F735810850C368"]
-			description: ["A fine mineral said to be steeped with the souls of those interred in the earth. "]
+			description: [
+				"A fine mineral said to be steeped with the souls of those interred in the earth. "
+				""
+				"Though common in the Nether, Soul Powder is also abundant in some spooky places in the Twilight Forest."
+			]
 			id: "126F4E070F219A8B"
 			rewards: [{
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"

--- a/kubejs/client_scripts/base/jei_descriptions.js
+++ b/kubejs/client_scripts/base/jei_descriptions.js
@@ -321,7 +321,7 @@ JEIEvents.information((event) => {
         {
             items: ['supplementaries:antique_ink'],
             text: [
-                `May be obtained through fishing, inside urns, or purchased from Cartographers.`,
+                `May be obtained very rarely through fishing, inside urns, or purchased from Cartographers.`,
                 ` `,
                 `For an easy supply, try an Aquatic Entangler with Junk Nets!`
             ]

--- a/kubejs/server_scripts/base/recipes/create/mixing.js
+++ b/kubejs/server_scripts/base/recipes/create/mixing.js
@@ -36,19 +36,19 @@ ServerEvents.recipes((event) => {
         {
             results: [{ fluid: 'sophisticatedcore:xp_still', amount: 60 }],
             ingredients: [{ item: 'create:experience_nugget' }],
-            heatRequirement: 'heated',
+            heatRequirement: 'superheated',
             id: `${id_prefix}experience_nugget_to_liquid`
         },
         {
             results: [{ fluid: 'sophisticatedcore:xp_still', amount: 60 }],
             ingredients: [{ item: 'ars_nouveau:experience_gem' }],
-            heatRequirement: 'heated',
+            heatRequirement: 'superheated',
             id: `${id_prefix}experience_gem_to_liquid`
         },
         {
             results: [{ fluid: 'sophisticatedcore:xp_still', amount: 240 }],
             ingredients: [{ item: 'ars_nouveau:greater_experience_gem' }],
-            heatRequirement: 'heated',
+            heatRequirement: 'superheated',
             id: `${id_prefix}greater_experience_gem_to_liquid`
         },
         {

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
@@ -108,6 +108,7 @@ ServerEvents.recipes((event) => {
         {
             output: 'ars_elemental:glyph_phantom_grasp',
             inputItems: [
+                { item: { tag: 'forge:essences/anima' } },
                 {
                     item: [
                         { item: 'twilightforest:phantom_helmet' },
@@ -115,7 +116,6 @@ ServerEvents.recipes((event) => {
                         { item: 'twilightforest:knight_phantom_trophy' }
                     ]
                 },
-                { item: { item: 'ars_elemental:anima_essence' } },
                 { item: { item: 'supplementaries:antique_ink' } }
             ],
             count: 1,
@@ -125,17 +125,24 @@ ServerEvents.recipes((event) => {
         {
             output: 'ars_nouveau:glyph_hex',
             inputItems: [
-                { item: { item: 'ars_nouveau:abjuration_essence' } },
+                { item: { tag: 'forge:essences/anima' } },
                 { item: { item: 'hexerei:belladonna_berries' } },
-                { item: { item: 'minecraft:blaze_rod' } },
-                { item: { item: 'minecraft:blaze_rod' } },
-                { item: { item: 'minecraft:blaze_rod' } },
-                { item: { item: 'ars_elemental:anima_essence' } },
                 { item: { item: 'supplementaries:antique_ink' } }
             ],
             count: 1,
             exp: 160,
             id: 'ars_nouveau:glyph_hex'
+        },
+        {
+            output: 'ars_nouveau:glyph_break',
+            inputItems: [
+                { item: { item: 'immersiveengineering:drillhead_steel' } },
+                { item: { tag: 'forge:essences/earth' } },
+                { item: { item: 'supplementaries:antique_ink' } }
+            ],
+            count: 1,
+            exp: 55,
+            id: 'ars_nouveau:glyph_break'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/fermenter.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/fermenter.js
@@ -1,0 +1,21 @@
+ServerEvents.recipes((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/immersiveengineering/fermenter/';
+
+    const recipes = [
+        {
+            fluid: { amount: 60, fluid: 'pneumaticcraft:ethanol' },
+            input: [{ item: 'minecraft:nether_wart' }],
+            energy: 64,
+            id: `${id_prefix}ethanol_from_nether_wart`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'immersiveengineering:fermenter';
+
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/industrialforegoing/laser_drill_ore.js
+++ b/kubejs/server_scripts/expert/recipes/industrialforegoing/laser_drill_ore.js
@@ -16,11 +16,11 @@ ServerEvents.recipes((event) => {
                     blacklist: {},
                     whitelist: {
                         type: 'minecraft:worldgen/biome',
-                        values: biomes.in_the_nether.concat([
+                        values: [
                             'twilightforest:dark_forest',
                             'twilightforest:dark_forest_center',
                             'twilightforest:spooky_forest'
-                        ])
+                        ].concat(biomes.in_the_nether)
                     }
                 },
                 {

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
@@ -170,6 +170,15 @@ ServerEvents.recipes((event) => {
             temperature: { max_temp: 423, min_temp: 373 },
             speed: 2.0,
             id: `${id_prefix}cured_rubber`
+        },
+        {
+            fluid_output: { amount: 60, fluid: 'pneumaticcraft:ethanol' },
+            fluid_input: { type: 'pneumaticcraft:fluid', amount: 10, tag: 'pneumaticcraft:yeast_culture' },
+            item_input: [{ item: 'minecraft:nether_wart' }],
+            exothermic: true,
+            speed: 0.25,
+            temperature: { max_temp: 333, min_temp: 303 },
+            id: `${id_prefix}ethanol_from_nether_wart`
         }
     ];
 

--- a/kubejs/startup_scripts/base/brewing_registry.js
+++ b/kubejs/startup_scripts/base/brewing_registry.js
@@ -277,6 +277,11 @@ MoreJSEvents.registerPotionBrewing((event) => {
             reagent: 'minecraft:honeycomb',
             input: 'minecraft:awkward',
             output: 'minecraft:healing'
+        },
+        {
+            reagent: 'minecraft:glowstone_dust',
+            input: 'apotheosis:knowledge',
+            output: 'apotheosis:strong_knowledge'
         }
     ];
 

--- a/kubejs/startup_scripts/expert/brewing_remove.js
+++ b/kubejs/startup_scripts/expert/brewing_remove.js
@@ -1,5 +1,8 @@
 // priority: 100
 MoreJSEvents.registerPotionBrewing((event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
     // Documentation: https://github.com/AlmostReliable/morejs/wiki/Potion-Brewing
     /**
      * Removes all potions where an awkward potion is used as the base potion ingredient.
@@ -10,5 +13,5 @@ MoreJSEvents.registerPotionBrewing((event) => {
      */
     //event.removeByPotion("minecraft:awkward", null, null);
 
-    event.removeByPotion('apotheosis:knowledge', 'minecraft:experience_bottle', null);
+    event.removeByPotion(null, 'minecraft:nether_wart', null);
 });


### PR DESCRIPTION
- XP Melting now requires Superheating in Create to avoid a conflict with potion brewing 
- [Expert] Awkward potions are no longer brewable with Netherwart to promote the use of the far easier to obtain Abjuration Essence
-   [Expert] The Break Glyph no longer requires Iron, making it accessible closer to when a Tier 2 book is available
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/63abdb50-5d8b-47fa-a770-a7f522ef9a52)
-   [Expert] Soul powder quest has been updated to help clarify that it can be mined in the Twilight Forest too 
