### PR TITLE
New Ars Elemental Glyphs

### DIFF
--- a/config/ars_elemental/glyph_envenom.toml
+++ b/config/ars_elemental/glyph_envenom.toml
@@ -1,0 +1,29 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 20
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 2
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Prevents the given glyph from being used in the same spell as the given glyph
+	#Example entry: "glyph_burst"
+	invalid_combos = []
+	#Potion duration, in seconds
+	#Range: > 0
+	potion_time = 5
+	#Extend time duration, in seconds
+	#Range: > 0
+	extend_time = 5
+

--- a/config/ars_elemental/glyph_spike.toml
+++ b/config/ars_elemental/glyph_spike.toml
@@ -1,0 +1,27 @@
+
+#General settings
+[general]
+	#Is Enabled?
+	enabled = true
+	#Cost
+	#Range: > -2147483648
+	cost = 30
+	#Is Starter Glyph?
+	starter = false
+	#The maximum number of times this glyph may appear in a single spell
+	#Range: > 1
+	per_spell_limit = 2147483647
+	#The tier of the glyph
+	#Range: 1 ~ 99
+	glyph_tier = 2
+	#Limits the number of times a given augment may be applied to a given effect
+	#Example entry: "glyph_amplify=5"
+	augment_limits = []
+	#Prevents the given glyph from being used in the same spell as the given glyph
+	#Example entry: "glyph_burst"
+	invalid_combos = []
+	#Range: 0.0 ~ 2.147483647E9
+	damage = 8.0
+	#Range: 0.0 ~ 2.147483647E9
+	amplify = 2.5
+

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
@@ -143,6 +143,30 @@ ServerEvents.recipes((event) => {
             count: 1,
             exp: 55,
             id: 'ars_nouveau:glyph_break'
+        },
+        {
+            output: 'ars_elemental:glyph_spike',
+            inputItems: [
+                { item: { item: 'minecraft:pointed_dripstone' } },
+                { item: { tag: 'forge:ingots/depths' } },
+                { item: { tag: 'forge:essences/earth' } },
+                { item: { item: 'supplementaries:antique_ink' } }
+            ],
+            count: 1,
+            exp: 55,
+            id: 'ars_elemental:glyph_spike'
+        },
+        {
+            output: 'ars_elemental:glyph_envenom',
+            inputItems: [
+                { item: { item: 'hexerei:belladonna_berries' } },
+                { item: { item: 'minecraft:fermented_spider_eye' } },
+                { item: { item: 'hexerei:dried_belladonna_flowers' } },
+                { item: { item: 'supplementaries:antique_ink' } }
+            ],
+            count: 1,
+            exp: 55,
+            id: 'ars_elemental:glyph_envenom'
         }
     ];
 


### PR DESCRIPTION
- [Expert] Recipes changed for Envenom and Spike to make them craftable at a reasonable stage