### PR TITLE
fix refinery crash

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -37,7 +37,7 @@
 -   [Normal] Remove unwanted thermal compat recipes [\#772](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/772)
 -   [Normal] Fix missing Pulverizer ore processing recipes [\#755](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/755)
 -   [Expert] Set Default Exit Dim for BumbleZone to Twilight Forest [\#746](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/746)
--   [Expert] It should no longer be possible to go to the End using a vanilla portal [\#763](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/763)
+-   [Expert] It should no longer be possible to go to the End using a vanilla portal. Existing portals are unaffected [\#763](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/763)
 -   [Expert] Fix misleading spell turret quest [\#771](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/771)
 
 ---

--- a/kubejs/server_scripts/expert/recipes/immersiveengineering/fermenter.js
+++ b/kubejs/server_scripts/expert/recipes/immersiveengineering/fermenter.js
@@ -6,9 +6,9 @@ ServerEvents.recipes((event) => {
 
     const recipes = [
         {
-            fluid: { amount: 60, fluid: 'pneumaticcraft:ethanol' },
+            fluid: { amount: 120, fluid: 'pneumaticcraft:ethanol' },
             input: [{ item: 'minecraft:nether_wart' }],
-            energy: 64,
+            energy: 400,
             id: `${id_prefix}ethanol_from_nether_wart`
         }
     ];

--- a/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/expert/recipes/pneumaticcraft/thermo_plant.js
@@ -172,7 +172,7 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}cured_rubber`
         },
         {
-            fluid_output: { amount: 60, fluid: 'pneumaticcraft:ethanol' },
+            fluid_output: { amount: 120, fluid: 'pneumaticcraft:ethanol' },
             fluid_input: { type: 'pneumaticcraft:fluid', amount: 10, tag: 'pneumaticcraft:yeast_culture' },
             item_input: [{ item: 'minecraft:nether_wart' }],
             exothermic: true,


### PR DESCRIPTION
energy was set too low, causing the machine to crash. Increased energy consumption but also increased output.