### PR TITLE
Better Unstable Gifts

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Enigmatica 9 v1.17.0
+
+### 🌟 Improvements
+
+-   Changes the Belt of Unstable Gifts to remove annoying vision changing buffs (Night Vision, Speed) while adding many other fun buffs. [\#803](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/803)
+
+---
+
 ### Enigmatica 9 v1.16.1
 
 🚀 Forge-1.19.2-43.2.14 | [📜 Mod Updates](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/changelog_mods_1.16.1.md) | [📋 Modlist](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/modlist_1.16.1.md)

--- a/kubejs/server_scripts/base/tags/mob_effect/ars_nouveau/unstable_gifts.js
+++ b/kubejs/server_scripts/base/tags/mob_effect/ars_nouveau/unstable_gifts.js
@@ -1,0 +1,32 @@
+ServerEvents.tags('mob_effect', (event) => {
+    event
+        .get('ars_nouveau:unstable_gifts')
+        .removeAll()
+        .add([
+            'apotheosis:knowledge',
+            'apotheosis:vitality',
+            'ars_nouveau:mana_regen',
+            'ars_nouveau:recovery',
+            'ars_nouveau:shielding',
+            'ars_nouveau:spell_damage',
+            'cofh_core:clarity',
+            'cofh_core:cold_resistance',
+            'cofh_core:explosion_resistance',
+            'cofh_core:lightning_resistance',
+            'cofh_core:magic_resistance',
+            'cofh_core:slimed',
+            'cofh_core:true_invisibility',
+            'farmersdelight:comfort',
+            'farmersdelight:nourishment',
+            'minecraft:absorption',
+            'minecraft:fire_resistance',
+            'minecraft:haste',
+            'minecraft:regeneration',
+            'minecraft:resistance',
+            'minecraft:saturation',
+            'minecraft:slow_falling',
+            'minecraft:strength',
+            'sushigocrafting:acquired_taste',
+            'sushigocrafting:small_bites'
+        ]);
+});

--- a/kubejs/server_scripts/base/tags/mob_effect/ars_nouveau/unstable_gifts.js
+++ b/kubejs/server_scripts/base/tags/mob_effect/ars_nouveau/unstable_gifts.js
@@ -15,7 +15,6 @@ ServerEvents.tags('mob_effect', (event) => {
             'cofh_core:lightning_resistance',
             'cofh_core:magic_resistance',
             'cofh_core:slimed',
-            'cofh_core:true_invisibility',
             'farmersdelight:comfort',
             'farmersdelight:nourishment',
             'minecraft:absorption',


### PR DESCRIPTION
Removes potion effects from the Belt of Unstable Gifts that change the way the player sees (FOV or night vision).

Adds a bunch of other fun effects. 

https://github.com/EnigmaticaModpacks/Enigmatica9/issues/801