### PR TITLE
Quest Typo fixes

### DIFF
--- a/config/ftbquests/quests/chapters/tools.snbt
+++ b/config/ftbquests/quests/chapters/tools.snbt
@@ -801,7 +801,7 @@
 			description: [
 				"Upgrades to basic Shovels and Hammers, these tools mine a 3x3 area. "
 				""
-				"Apply Power of the Depth to them to the depth of mining. Each level of the enchant will cause the tool to mine another block deep."
+				"Apply Power of the Depth to them to increase the depth of mining. Each level of the enchant will cause the tool to mine another block deep."
 			]
 			icon: {
 				Count: 1b

--- a/config/ftbquests/quests/chapters/tools_expert.snbt
+++ b/config/ftbquests/quests/chapters/tools_expert.snbt
@@ -780,7 +780,7 @@
 			description: [
 				"Upgrades to basic Shovels and Hammers, these tools mine a 3x3 area. "
 				""
-				"Apply Power of the Depth to them to the depth of mining. Each level of the enchant will cause the tool to mine another block deep."
+				"Apply Power of the Depth to them to increase the depth of mining. Each level of the enchant will cause the tool to mine another block deep."
 			]
 			icon: {
 				Count: 1b


### PR DESCRIPTION
This PR fixes few of the typos in quests 😄

Words with the `dark background` indicate changes. Crossed out means deletion.

- Tools -> Excavators: Apply Power of the Depth to them to `increase` the depth of mining.

I will keep this PR as draft until I stop playin today, as it's possible I will find few more typos to fix, and doing PR for each change is just making a bit of mess 😄