### PR TITLE
More missing crushing recipes

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -   Excavator quest now accepts any tier of excavator/hammer [\#827](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/827)
 
+### 🐛 Fixed Bugs
+
+-   [Normal] Fix missing crushing recipes for Copper/Gold/Iron [\#830](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/830)
+
 ---
 
 ### Enigmatica 9 v1.17.2

--- a/kubejs/server_scripts/normal/recipes/occultism/crushing.js
+++ b/kubejs/server_scripts/normal/recipes/occultism/crushing.js
@@ -28,9 +28,30 @@ ServerEvents.recipes((event) => {
         {
             output: 'minecraft:netherite_scrap',
             input: '#forge:ores/netherite',
-            crushing_time: 90,
+            crushing_time: 200,
             ignore_occultism_multiplier: false,
             id: `${id_prefix}netherite_crushing`
+        },
+        {
+            output: '2x emendatusenigmatica:iron_dust',
+            input: '#forge:raw_materials/iron',
+            crushing_time: 200,
+            ignore_occultism_multiplier: false,
+            id: `${id_prefix}iron_dust`
+        },
+        {
+            output: '2x emendatusenigmatica:gold_dust',
+            input: '#forge:raw_materials/gold',
+            crushing_time: 200,
+            ignore_occultism_multiplier: false,
+            id: `${id_prefix}gold_dust`
+        },
+        {
+            output: '2x emendatusenigmatica:copper_dust',
+            input: '#forge:raw_materials/copper',
+            crushing_time: 200,
+            ignore_occultism_multiplier: false,
+            id: `${id_prefix}copper_dust`
         }
     ];
 


### PR DESCRIPTION
Seems we were relying on EE to add back Occultism Crushing recipes for Iron/Gold/Copper and those are no longer handled by it since it's not doing the Raw counterparts for these materials. 

Re-added. 