### PR TITLE
Quest clarification surround lead, sensitive, and glyphs in general

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -9,6 +9,8 @@
 -   PNC's new Thermostat module is now slightly easier to craft and has been given a quest [\#829](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/829)
 -   [Expert] Lich should no longer spill loot on the ground outside the chest [\#829](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/829)
 -   Badlands Creepers now drop terracotta instead of gold nuggets [\#829](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/829)
+-   [Expert] Quests have been clarified to help with Lead/Sensitive/Glyph/Antique Ink progression [\#832](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/832)
+-   A number of in world conversions now have Lychee dummy recipes to highlight them, such as getting Straw from Grass or making Wixie Cauldrons [\#832](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/832)
 
 ### 🐛 Fixed Bugs
 

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -633,7 +633,7 @@
 				}
 			]
 			title: "Applied Energistics"
-			x: -9.5d
+			x: -10.0d
 			y: 3.5d
 		}
 		{
@@ -2626,7 +2626,7 @@
 				}
 			]
 			title: "Energy Transfer"
-			x: -8.5d
+			x: -8.0d
 			y: 3.5d
 		}
 		{
@@ -2739,6 +2739,13 @@
 			]
 			icon: "supplementaries:antique_ink"
 			id: "7D67B1A9AC1F4445"
+			rewards: [{
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
+				icon: "kubejs:scavengers_delight"
+				id: "3647C7DB6CC3E944"
+				title: "Scavenger's Delight"
+				type: "command"
+			}]
 			shape: "hexagon"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -449,7 +449,15 @@
 		}
 		{
 			dependencies: ["4830632A0E6E9651"]
-			description: ["By balancing the outward force of Aura with the inward crushing of this spell, we’re able to reach a stable equilibrium that is strong and durable enough to assist in advanced metallurgy: Compressed Stone."]
+			description: [
+				"By balancing the outward force of Aura with the inward crushing of this spell, we’re able to reach a stable equilibrium that is strong and durable enough to assist in advanced metallurgy: Compressed Stone."
+				""
+				"The following spell form will crush blocks placed in the world: "
+				""
+				"&5Touch&r > &aCrush&r"
+				""
+				"Note: Sensitive is &nnot&r required for blocks."
+			]
 			id: "79B755D0BDB6A8B7"
 			rewards: [{
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
@@ -908,7 +916,7 @@
 				item: "ars_nouveau:scribes_table"
 				type: "item"
 			}]
-			x: -9.5d
+			x: -8.5d
 			y: 0.5d
 		}
 		{
@@ -1111,7 +1119,7 @@
 				}
 			]
 			title: "Summon Death Tome"
-			x: -8.5d
+			x: -9.5d
 			y: 0.5d
 		}
 		{

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -410,6 +410,7 @@
 				item: "twilightforest:ironwood_ingot"
 				type: "item"
 			}]
+			title: "Ironwood"
 			x: -2.5d
 			y: -2.5d
 		}
@@ -456,7 +457,7 @@
 				""
 				"&5Touch&r > &aCrush&r"
 				""
-				"Note: Sensitive is &nnot&r required for blocks."
+				"Note: Sensitive is &nnot&r required for crushing blocks."
 			]
 			id: "79B755D0BDB6A8B7"
 			rewards: [{
@@ -633,7 +634,7 @@
 			]
 			title: "Applied Energistics"
 			x: -9.5d
-			y: 3.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["7CFD3DFD4C593EB5"]
@@ -873,7 +874,7 @@
 		}
 		{
 			dependencies: ["73CDA6ED2393DE42"]
-			description: ["Perhaps paying a visit to the local mage tower will turn up more information, or at least more useful tools to assist in restoring the Tree of Life?"]
+			description: ["Perhaps paying a visit to the local mage tower will turn up more information, or at least more useful tools, to assist in restoring the Tree of Life?"]
 			hide_dependency_lines: true
 			icon: "ars_nouveau:novice_spell_book"
 			id: "370C40BCC3A6A055"
@@ -894,14 +895,8 @@
 			y: -0.5d
 		}
 		{
-			dependencies: ["28A304E0F1600640"]
-			description: [
-				"Though many glyphs may be found and used to repair the spell book, the Scribe’s Table may also be used to craft any glyph. "
-				""
-				"Finding proper spell ink, however, may prove more difficult as it must be specially prepared using a process that can take years. "
-				""
-				"It was once heavily traded by the seafaring folk that specialized in its creation. Perhaps some could be retrieved with some good old-fashioned trawling. "
-			]
+			dependencies: ["7D67B1A9AC1F4445"]
+			description: ["With a steady supply of Antique Ink secured, glyphs may finally be crafted. Of course, using higher tier glyphs will still require further repair of the Spell Book. "]
 			id: "7507572BD048B6C9"
 			rewards: [{
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/sorcerers_delight"
@@ -916,8 +911,8 @@
 				item: "ars_nouveau:scribes_table"
 				type: "item"
 			}]
-			x: -8.5d
-			y: 0.5d
+			x: -8.0d
+			y: 1.5d
 		}
 		{
 			dependencies: ["11AB47232D9F5D6D"]
@@ -1084,6 +1079,7 @@
 				""
 				"Perform this ritual to summon a murder of Death Tomes. They’ll be an excellent way to supplement the missing glyphs in this newfound spell book."
 			]
+			hide_dependency_lines: true
 			icon: {
 				Count: 1b
 				id: "gateways:gate_pearl"
@@ -1119,8 +1115,8 @@
 				}
 			]
 			title: "Summon Death Tome"
-			x: -9.5d
-			y: 0.5d
+			x: -10.0d
+			y: 1.5d
 		}
 		{
 			dependencies: ["11AB47232D9F5D6D"]
@@ -1995,8 +1991,8 @@
 				type: "item"
 			}]
 			title: "Certus Farming"
-			x: -10.0d
-			y: 2.0d
+			x: -9.5d
+			y: 2.5d
 		}
 		{
 			dependencies: ["11AB47232D9F5D6D"]
@@ -2067,8 +2063,8 @@
 				item: "ars_nouveau:glyph_dispel"
 				type: "item"
 			}]
-			x: -10.0d
-			y: -0.5d
+			x: -9.5d
+			y: 0.5d
 		}
 		{
 			dependencies: ["7AD5D1665CA3DF4F"]
@@ -2299,8 +2295,8 @@
 					type: "item"
 				}
 			]
-			x: -8.0d
-			y: -0.5d
+			x: -8.5d
+			y: 0.5d
 		}
 		{
 			dependencies: ["345CBD118EAA0C09"]
@@ -2413,67 +2409,6 @@
 			}]
 			x: -3.5d
 			y: -3.0d
-		}
-		{
-			dependencies: ["3B372F597A05E777"]
-			description: [
-				"While the Dark Tower itself is largely infested with Towerwood Borers, it’s trivial to attract more of the critters. Getting rid of them, on the other hand, may prove a little more complicated. "
-				""
-				"They don’t come alone, so care should be taken!"
-			]
-			hide_dependency_lines: true
-			icon: {
-				Count: 1b
-				id: "gateways:gate_pearl"
-				tag: {
-					gateway: "gateways:swarm_gate_large"
-				}
-			}
-			id: "5D1FCC45134CB879"
-			rewards: [{
-				count: 4
-				id: "291E911003FDDDA7"
-				item: "emendatusenigmatica:carminite_gem"
-				type: "item"
-			}]
-			shape: "hexagon"
-			tasks: [
-				{
-					entity: "minecraft:endermite"
-					icon: "minecraft:spawner"
-					id: "534A73E9BF329237"
-					type: "kill"
-					value: 5L
-				}
-				{
-					entity: "twilightforest:towerwood_borer"
-					id: "2E7B9A411B813DED"
-					type: "kill"
-					value: 5L
-				}
-				{
-					entity: "minecraft:silverfish"
-					icon: "minecraft:spawner"
-					id: "1567106A573CDBAD"
-					type: "kill"
-					value: 5L
-				}
-				{
-					id: "7849128B7816AA53"
-					item: {
-						Count: 1b
-						id: "gateways:gate_pearl"
-						tag: {
-							gateway: "gateways:swarm_gate_small"
-						}
-					}
-					optional_task: true
-					type: "item"
-				}
-			]
-			title: "Summon Mite Swarms"
-			x: -9.0d
-			y: 2.0d
 		}
 		{
 			dependencies: ["16E90BC107468EC2"]
@@ -2692,7 +2627,7 @@
 			]
 			title: "Energy Transfer"
 			x: -8.5d
-			y: 3.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["75C38D71F1A04EB4"]
@@ -2735,8 +2670,8 @@
 				}
 			]
 			title: "Plastic"
-			x: -8.0d
-			y: 2.0d
+			x: -8.5d
+			y: 2.5d
 		}
 		{
 			dependencies: ["73CDA6ED2393DE42"]
@@ -2792,6 +2727,39 @@
 			title: "Nomadic Life"
 			x: -3.5d
 			y: -6.5d
+		}
+		{
+			dependencies: ["28A304E0F1600640"]
+			description: [
+				"Though many glyphs may be found and used to repair the spell book, they may also be crafted with appropriate materials. "
+				""
+				"Finding proper spell ink, however, may prove rather difficult as it must be specially prepared using a process that can take years. "
+				""
+				"It was once heavily traded by the seafaring folk that specialized in its creation. Perhaps some could be retrieved with some good old-fashioned trawling. "
+			]
+			icon: "supplementaries:antique_ink"
+			id: "7D67B1A9AC1F4445"
+			shape: "hexagon"
+			tasks: [
+				{
+					id: "1FF77511CCF22E34"
+					item: "thermal:device_fisher"
+					type: "item"
+				}
+				{
+					id: "479957F36710ECBC"
+					item: "thermal:junk_net"
+					type: "item"
+				}
+				{
+					id: "4AC9100D64D9A852"
+					item: "supplementaries:antique_ink"
+					type: "item"
+				}
+			]
+			title: "Antique Ink"
+			x: -9.0d
+			y: 1.5d
 		}
 	]
 	title: "Chapter One"

--- a/config/ftbquests/quests/chapters/thermal_series_expert.snbt
+++ b/config/ftbquests/quests/chapters/thermal_series_expert.snbt
@@ -957,11 +957,6 @@
 			min_width: 300
 			rewards: [
 				{
-					id: "33D323C619C928A1"
-					item: "thermal:junk_net"
-					type: "item"
-				}
-				{
 					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/thermal_series/rare"
 					icon: "kubejs:rare_lootbox"
 					id: "67C2F821185E408C"

--- a/kubejs/client_scripts/constants/jei_hidden_disabled.js
+++ b/kubejs/client_scripts/constants/jei_hidden_disabled.js
@@ -177,7 +177,7 @@ jei.base.fluids.hidden = [
     'create:honey',
     'cofh_core:honey'
 ];
-jei.base.categories.hidden = ['twilightforest:uncrafting', 'emi_loot:chest_loot'];
+jei.base.categories.hidden = ['twilightforest:uncrafting', 'emi_loot:chest_loot', 'emi_loot:block_drops'];
 jei.base.recipes.hidden = [
     {
         category: 'minecraft:crafting',

--- a/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
+++ b/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
@@ -99,6 +99,85 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}straw_from_rice_panicles`
+        },
+        {
+            ghost: true,
+            type: 'lychee:block_interacting',
+            item_in: { item: 'ars_nouveau:drygmy_charm' },
+            block_in: 'minecraft:mossy_cobblestone',
+            post: [
+                {
+                    type: 'place',
+                    block: {
+                        blocks: ['ars_nouveau:drygmy_stone'],
+                        state: { converted: 'true' }
+                    }
+                }
+            ],
+            id: `${id_prefix}drygmy_stone`
+        },
+        {
+            ghost: true,
+            type: 'lychee:block_interacting',
+            item_in: { item: 'ars_nouveau:whirlisprig_charm' },
+            block_in: { tag: 'minecraft:flowers' },
+            post: [
+                {
+                    type: 'place',
+                    block: {
+                        blocks: ['ars_nouveau:whirlisprig_flower'],
+                        state: { converted: 'true' }
+                    }
+                }
+            ],
+            id: `${id_prefix}whirlisprig_flower`
+        },
+        {
+            ghost: true,
+            type: 'lychee:block_interacting',
+            item_in: { item: 'ars_elemental:siren_charm' },
+            block_in: 'minecraft:prismarine',
+            post: [
+                {
+                    type: 'place',
+                    block: {
+                        blocks: ['ars_elemental:mermaid_rock'],
+                        state: { converted: 'true' }
+                    }
+                }
+            ],
+            id: `${id_prefix}siren_stone`
+        },
+        {
+            ghost: true,
+            type: 'lychee:block_interacting',
+            item_in: { item: 'ars_nouveau:wixie_charm' },
+            block_in: 'minecraft:cauldron',
+            post: [
+                {
+                    type: 'place',
+                    block: {
+                        blocks: ['ars_nouveau:wixie_cauldron'],
+                        state: { converted: 'true' }
+                    }
+                }
+            ],
+            id: `${id_prefix}wixie_cauldron`
+        },
+        {
+            ghost: true,
+            type: 'lychee:block_interacting',
+            item_in: { item: 'ars_nouveau:bookwyrm_charm' },
+            block_in: 'minecraft:lectern',
+            post: [
+                {
+                    type: 'place',
+                    block: {
+                        blocks: ['ars_nouveau:storage_lectern']
+                    }
+                }
+            ],
+            id: `${id_prefix}storage_lectern`
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
+++ b/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
@@ -45,6 +45,60 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}lava`
+        },
+        {
+            ghost: true,
+            item_in: { tag: 'farmersdelight:straw_harvesters' },
+            type: 'lychee:block_clicking',
+            block_in: { blocks: ['minecraft:grass', 'minecraft:tall_grass'] },
+            post: [
+                {
+                    type: 'drop_item',
+                    contextual: [{ type: 'chance', chance: 0.2 }],
+                    item: 'farmersdelight:straw'
+                }
+            ],
+            id: `${id_prefix}straw_from_grass`
+        },
+        {
+            ghost: true,
+            item_in: { tag: 'farmersdelight:straw_harvesters' },
+            type: 'lychee:block_clicking',
+            block_in: { blocks: ['farmersdelight:sandy_shrub'] },
+            post: [
+                {
+                    type: 'drop_item',
+                    contextual: [{ type: 'chance', chance: 0.3 }],
+                    item: 'farmersdelight:straw'
+                }
+            ],
+            id: `${id_prefix}straw_from_sandy_shrub`
+        },
+        {
+            ghost: true,
+            item_in: { tag: 'farmersdelight:straw_harvesters' },
+            type: 'lychee:block_clicking',
+            block_in: { blocks: ['minecraft:wheat'], state: { age: '7' } },
+            post: [
+                {
+                    type: 'drop_item',
+                    item: 'farmersdelight:straw'
+                }
+            ],
+            id: `${id_prefix}straw_from_wheat`
+        },
+        {
+            ghost: true,
+            item_in: { tag: 'farmersdelight:straw_harvesters' },
+            type: 'lychee:block_clicking',
+            block_in: { blocks: ['farmersdelight:rice_panicles'], state: { age: '3' } },
+            post: [
+                {
+                    type: 'drop_item',
+                    item: 'farmersdelight:straw'
+                }
+            ],
+            id: `${id_prefix}straw_from_rice_panicles`
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
+++ b/kubejs/server_scripts/base/recipes/lychee/jei_dummy_recipes.js
@@ -163,21 +163,6 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}wixie_cauldron`
-        },
-        {
-            ghost: true,
-            type: 'lychee:block_interacting',
-            item_in: { item: 'ars_nouveau:bookwyrm_charm' },
-            block_in: 'minecraft:lectern',
-            post: [
-                {
-                    type: 'place',
-                    block: {
-                        blocks: ['ars_nouveau:storage_lectern']
-                    }
-                }
-            ],
-            id: `${id_prefix}storage_lectern`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/thermal/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/shaped.js
@@ -227,10 +227,10 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'thermal:junk_net',
-            pattern: ['ABA', 'B B', 'ABA'],
+            pattern: ['ABA', 'BBB', 'ABA'],
             key: {
                 A: '#forge:nuggets/lead',
-                B: 'thermal:beekeeper_fabric'
+                B: 'farmersdelight:safety_net'
             },
             id: 'thermal:junk_net'
         },


### PR DESCRIPTION
Junk Net is no longer given out as a quest reward as it was buried in the Thermal section.

Instead, the craft is simplified to not require the pressure chamber. 

![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/0f8fae3b-b68e-4802-9294-7d52658f1cf1)


Additionally, Lychee has been used to add ghost recipes for obtaining straw for the net. 

![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/953327f8-0dc2-4f39-aa1b-cb714153889f)

Quests have been reworked in CH 1 to direct people to the aquatic entangler for ink
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/3ab25709-d4dc-4412-beb2-470d5295518f)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/ea161594-26c4-4c9d-869d-00fcdc06ec41)

Similarly, the Compressed Stone quest has been updated to repeat that Sensitive is not required for crushing the stone
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/f2edaaf9-e102-46d0-8551-c6f598a8af42)
