### PR TITLE
Fix Void Safety Net Latency issues + Fall Damage Death after tp

### DIFF
--- a/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
+++ b/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
@@ -1,14 +1,17 @@
 EntityEvents.hurt((event) => {
     const { entity, source, level, server } = event;
-    if (!entity.isPlayer() || entity.isFake()) return;
+    if (!entity.isPlayer() || entity.isFake()) {
+        return;
+    }
 
     let currentTime = level.getDayTime();
     if (
-        server.persistentData['lastVoidTime_' + entity.getUsername()] &&
-        server.persistentData['lastVoidTime_' + entity.getUsername()] + 40 > currentTime
-    )
+        entity.persistentData['lastVoidTime'] &&
+        entity.persistentData['lastVoidTime'] + 40 > currentTime
+    ) {
         return;
-    server.persistentData['lastVoidTime_' + entity.getUsername()] = currentTime;
+    }
+    entity.persistentData['lastVoidTime'] = currentTime;
 
     let player = entity;
     let currentDimension = String(level.getDimension());

--- a/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
+++ b/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
@@ -1,8 +1,11 @@
 EntityEvents.hurt((event) => {
     const { entity, source, level, server } = event;
-    if (!entity.isPlayer() || entity.isFake()) {
-        return;
-    }
+    if (!entity.isPlayer() || entity.isFake()) return;
+
+    let currentTime = level.getDayTime();
+    if (server.persistentData["lastVoidTime_" + entity.getUsername()] && server.persistentData["lastVoidTime_" + entity.getUsername()] + 40 > currentTime) return;
+    server.persistentData["lastVoidTime_" + entity.getUsername()] = currentTime;
+
     let player = entity;
     let currentDimension = String(level.getDimension());
     let watchDimensions = ['compact_world', 'nomadictents', 'the_end'];

--- a/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
+++ b/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
@@ -43,7 +43,7 @@ EntityEvents.hurt((event) => {
         });
         server.runCommandSilent(`effect give ${username} minecraft:hunger 8 255 true`);
         // Add slow fall effect to save players from fall damage after teleportation.
-        server.runCommandSilent(`effect give ${username} minecraft:slow_falling 4 255 true`)
+        server.runCommandSilent(`effect give ${username} minecraft:slow_falling 4 255 true`);
         event.cancel();
     }
 });

--- a/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
+++ b/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
@@ -5,10 +5,7 @@ EntityEvents.hurt((event) => {
     }
 
     let currentTime = level.getDayTime();
-    if (
-        entity.persistentData['lastVoidTime'] &&
-        entity.persistentData['lastVoidTime'] + 40 > currentTime
-    ) {
+    if (entity.persistentData['lastVoidTime'] && entity.persistentData['lastVoidTime'] + 40 > currentTime) {
         return;
     }
     entity.persistentData['lastVoidTime'] = currentTime;

--- a/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
+++ b/kubejs/server_scripts/base/entity_events/hurt/void_safety_net.js
@@ -38,7 +38,8 @@ EntityEvents.hurt((event) => {
             server.runCommandSilent(`effect clear ${username} ${effect}`);
         });
         server.runCommandSilent(`effect give ${username} minecraft:hunger 8 255 true`);
-
+        // Add slow fall effect to save players from fall damage after teleportation.
+        server.runCommandSilent(`effect give ${username} minecraft:slow_falling 4 255 true`)
         event.cancel();
     }
 });

--- a/kubejs/server_scripts/expert/recipes/minecraft/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/minecraft/shaped.js
@@ -187,6 +187,16 @@ ServerEvents.recipes((event) => {
                 C: '#forge:gems/nitro'
             },
             id: `minecraft:end_crystal`
+        },
+        {
+            output: '2x minecraft:tripwire_hook',
+            pattern: ['A', 'B', 'C'],
+            key: {
+                A: '#forge:ingots/tin',
+                B: '#forge:rods/wooden',
+                C: '#minecraft:planks'
+            },
+            id: 'minecraft:tripwire_hook'
         }
     ];
 


### PR DESCRIPTION
This PR Fixes Void Safety Net loop, that was possible to happen on servers due to network latency.

It adds a delay of 40 ticks between teleporation attempts, to allow player from actually teleporting out from the void :D
It also adds a slow falling effect for 4 seconds, to save players from fall damage death after teleporation

Additionally, make the Tripwire hook cheaper, replacing the Iron Ingot with Tin 😄
![tripwire_hook](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/60540476/fafa13ae-dc0f-4d5d-96e9-a09d959e12f8)
