### PR TITLE
Swap order of Hidden Quest and Getting Started chapters

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   [Expert] Remove broken recipes for Iesnium Dust [\#855](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/855)
 -   Remove unintended Osmium ore recipe from Pulverizer [\#855](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/855)
 -   [Expert] Fixed typo in Nomadic Tent quest [\#857](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/857)
+-   Hidden quests should no longer show by default when opening the quest book [\#860](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/860)
 
 ---
 

--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -5,7 +5,7 @@
 	group: ""
 	icon: "minecraft:nether_star"
 	id: "0000000000000044"
-	order_index: 1
+	order_index: 0
 	quest_links: [ ]
 	quests: [
 		{

--- a/config/ftbquests/quests/chapters/hidden_quests.snbt
+++ b/config/ftbquests/quests/chapters/hidden_quests.snbt
@@ -6,7 +6,7 @@
 	group: ""
 	icon: "minecraft:experience_bottle"
 	id: "0000000000000328"
-	order_index: 0
+	order_index: 1
 	quest_links: [ ]
 	quests: [
 		{


### PR DESCRIPTION
-   Hidden quests should no longer show by default when opening the quest book