### PR TITLE
Redstone mining level

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   [Expert] Adjust sophisticated storage stack upgrade recipes to account for new copper tier [\#878](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/878)
 -   [Expert] Market recipe now uses all 5 archwood saplings to help avoid confusion with the recipe [\#881](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/881)
+-   [Expert] Reduce mining level of Redstone to make the early game a little less confusing [\#888](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/888)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   [Expert] Removed disabled tank from IE quest chapters [\#879](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/879)
 -   [Expert] Fix for the honey compass quest for the Ancient City not completing [\#884](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/884)
 -   [Expert] Remove erroneous reference to hoes being used to clear grass [\#888](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/888)
+-   [Expert] Restore missing Dreamstone trade with the Queen Bee [\#888](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/888)
 
 ---
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   [Expert] Properly hide disabled limited barrels [\#878](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/878)
 -   [Expert] Removed disabled tank from IE quest chapters [\#879](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/879)
 -   [Expert] Fix for the honey compass quest for the Ancient City not completing [\#884](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/884)
+-   [Expert] Remove erroneous reference to hoes being used to clear grass [\#888](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/888)
 
 ---
 

--- a/config/configswapper/expert/config/emendatusenigmatica/material/redstone.json
+++ b/config/configswapper/expert/config/emendatusenigmatica/material/redstone.json
@@ -1,0 +1,22 @@
+{
+    "id": "redstone",
+    "source": "vanilla",
+    "localizedName": "Redstone",
+    "disableDefaultOre": true,
+    "processedTypes": ["ore"],
+    "properties": {
+        "materialType": "gem",
+        "harvestLevel": 1,
+        "hasParticles": true,
+        "blockRecipeType": 9,
+        "isEmissive": true
+    },
+    "oreDrop": {
+        "drop": "minecraft:redstone",
+        "min": 3,
+        "max": 9
+    },
+    "colors": {
+        "particlesColor": "ff0000"
+    }
+}

--- a/config/configswapper/normal/config/emendatusenigmatica/material/redstone.json
+++ b/config/configswapper/normal/config/emendatusenigmatica/material/redstone.json
@@ -1,0 +1,22 @@
+{
+    "id": "redstone",
+    "source": "vanilla",
+    "localizedName": "Redstone",
+    "disableDefaultOre": true,
+    "processedTypes": ["ore"],
+    "properties": {
+        "materialType": "gem",
+        "harvestLevel": 2,
+        "hasParticles": true,
+        "blockRecipeType": 9,
+        "isEmissive": true
+    },
+    "oreDrop": {
+        "drop": "minecraft:redstone",
+        "min": 3,
+        "max": 9
+    },
+    "colors": {
+        "particlesColor": "ff0000"
+    }
+}

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -2693,6 +2693,18 @@
 					id: "nomadictents:mallet"
 					tag: {
 						Damage: 0
+						Enchantments: [{
+							id: "minecraft:unbreaking"
+							lvl: 5s
+						}]
+						display: {
+							Name: "{\"text\":\"Sturdy Tent Mallet\"}"
+						}
+						"quark:RuneAttached": 1b
+						"quark:RuneColor": {
+							Count: 1b
+							id: "quark:blank_rune"
+						}
 					}
 				}
 				type: "item"

--- a/config/ftbquests/quests/chapters/chapter_one.snbt
+++ b/config/ftbquests/quests/chapters/chapter_one.snbt
@@ -2695,7 +2695,7 @@
 						Damage: 0
 						Enchantments: [{
 							id: "minecraft:unbreaking"
-							lvl: 5s
+							lvl: 3s
 						}]
 						display: {
 							Name: "{\"text\":\"Sturdy Tent Mallet\"}"

--- a/config/ftbquests/quests/chapters/tools.snbt
+++ b/config/ftbquests/quests/chapters/tools.snbt
@@ -138,8 +138,8 @@
 					type: "item"
 				}
 			]
-			x: -8.0d
-			y: -10.0d
+			x: -8.5d
+			y: -10.5d
 		}
 		{
 			dependencies: ["000000000000045C"]
@@ -355,7 +355,7 @@
 				}
 			]
 			x: -8.0d
-			y: -9.0d
+			y: -9.5d
 		}
 		{
 			dependencies: ["358FAB3D482C463A"]
@@ -421,7 +421,7 @@
 				}
 			]
 			x: -9.5d
-			y: -7.5d
+			y: -8.0d
 		}
 		{
 			dependencies: ["358FAB3D482C463A"]
@@ -435,7 +435,7 @@
 			}]
 			title: "Chainsaw"
 			x: -8.5d
-			y: -8.0d
+			y: -8.5d
 		}
 		{
 			dependencies: ["358FAB3D482C463A"]
@@ -459,7 +459,7 @@
 				}
 				type: "item"
 			}]
-			x: -11.5d
+			x: -10.5d
 			y: -11.0d
 		}
 		{
@@ -794,7 +794,7 @@
 			]
 			title: "Spells"
 			x: -10.5d
-			y: -7.5d
+			y: -8.0d
 		}
 		{
 			dependencies: ["358FAB3D482C463A"]
@@ -838,7 +838,7 @@
 				title: "Excavators"
 				type: "item"
 			}]
-			x: -8.5d
+			x: -9.5d
 			y: -11.0d
 		}
 		{
@@ -912,8 +912,8 @@
 					type: "item"
 				}
 			]
-			x: -12.0d
-			y: -10.0d
+			x: -11.5d
+			y: -10.5d
 		}
 		{
 			dependencies: ["358FAB3D482C463A"]
@@ -982,7 +982,7 @@
 				type: "item"
 			}]
 			x: -11.5d
-			y: -8.0d
+			y: -8.5d
 		}
 		{
 			dependencies: ["358FAB3D482C463A"]
@@ -1115,7 +1115,7 @@
 				}
 			]
 			x: -12.0d
-			y: -9.0d
+			y: -9.5d
 		}
 		{
 			dependencies: ["000000000000045C"]
@@ -1210,31 +1210,6 @@
 			}]
 			x: -10.0d
 			y: -13.0d
-		}
-		{
-			dependencies: ["358FAB3D482C463A"]
-			description: ["Great for quickly dismantling leaves on trees, the humble Hoe is also a workhorse out in the fields, scything down grass in large swaths with ease. "]
-			id: "25531EAF260F3944"
-			rewards: [{
-				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:loot_boxes/scavengers_delight"
-				icon: "kubejs:scavengers_delight"
-				id: "4734ACE72F894A6E"
-				title: "Scavenger's Delight"
-				type: "command"
-			}]
-			tasks: [{
-				id: "03615540784DE72D"
-				item: {
-					Count: 1b
-					id: "minecraft:wooden_hoe"
-					tag: {
-						Damage: 0
-					}
-				}
-				type: "item"
-			}]
-			x: -10.0d
-			y: -11.5d
 		}
 	]
 	title: "Equipment"

--- a/config/ftbquests/quests/chapters/tools_expert.snbt
+++ b/config/ftbquests/quests/chapters/tools_expert.snbt
@@ -138,7 +138,7 @@
 					type: "item"
 				}
 			]
-			x: -9.0d
+			x: -9.5d
 			y: -8.0d
 		}
 		{
@@ -307,7 +307,7 @@
 				}
 			]
 			x: -8.0d
-			y: -10.0d
+			y: -9.5d
 		}
 		{
 			dependencies: ["4650EB4575965AAD"]
@@ -370,7 +370,7 @@
 					type: "item"
 				}
 			]
-			x: -11.0d
+			x: -10.5d
 			y: -8.0d
 		}
 		{
@@ -411,8 +411,8 @@
 				type: "item"
 			}]
 			title: "Chainsaw"
-			x: -9.0d
-			y: -11.0d
+			x: -8.5d
+			y: -10.5d
 		}
 		{
 			dependencies: ["4650EB4575965AAD"]
@@ -436,8 +436,8 @@
 				}
 				type: "item"
 			}]
-			x: -8.0d
-			y: -9.0d
+			x: -8.5d
+			y: -8.5d
 		}
 		{
 			dependencies: ["4650EB4575965AAD"]
@@ -772,8 +772,8 @@
 				}
 			]
 			title: "Spells"
-			x: -11.0d
-			y: -11.0d
+			x: -11.5d
+			y: -10.5d
 		}
 		{
 			dependencies: ["4650EB4575965AAD"]
@@ -818,7 +818,7 @@
 				type: "item"
 			}]
 			x: -10.0d
-			y: -11.5d
+			y: -11.0d
 		}
 		{
 			dependencies: ["4650EB4575965AAD"]
@@ -933,7 +933,7 @@
 				type: "item"
 			}]
 			x: -12.0d
-			y: -10.0d
+			y: -9.5d
 		}
 		{
 			dependencies: ["4650EB4575965AAD"]
@@ -1046,8 +1046,8 @@
 					type: "item"
 				}
 			]
-			x: -12.0d
-			y: -9.0d
+			x: -11.5d
+			y: -8.5d
 		}
 		{
 			dependencies: ["291E5727DD1ADDF4"]
@@ -1202,30 +1202,6 @@
 			}]
 			x: -12.0d
 			y: -12.5d
-		}
-		{
-			dependencies: ["4650EB4575965AAD"]
-			description: ["Great for quickly dismantling leaves on trees, the humble Hoe is also a workhorse out in the fields, scything down grass in large swaths with ease. "]
-			id: "04EC298DE2818F2A"
-			rewards: [{
-				count: 8
-				id: "17A4B0F76044BC9A"
-				item: "farmersdelight:rich_soil"
-				type: "item"
-			}]
-			tasks: [{
-				id: "515526797B08891A"
-				item: {
-					Count: 1b
-					id: "minecraft:wooden_hoe"
-					tag: {
-						Damage: 0
-					}
-				}
-				type: "item"
-			}]
-			x: -10.0d
-			y: -7.5d
 		}
 	]
 	title: "Equipment"

--- a/kubejs/server_scripts/expert/recipes/the_bumblezone/bz_bee_queen_trades.js
+++ b/kubejs/server_scripts/expert/recipes/the_bumblezone/bz_bee_queen_trades.js
@@ -166,7 +166,7 @@ ServerEvents.lowPriorityData((event) => {
             ]
         },
         {
-            id: 'dream_stone_trades',
+            id: 'dimensionsal_storage_trades',
             wants: [{ id: 'kubejs:dimensional_storage_crystal', required: true }],
             possible_rewards: [
                 {


### PR DESCRIPTION
- [Expert] Reduce mining level of Redstone to make the early game a little less confusing. Players are seemingly getting stuck thinking they need an Iron Pick to mine it. Certus pick works fine, but this just completely removes any ambiguity. 
-   [Expert] Remove erroneous reference to hoes being used to clear grass 
-   [Expert] Restore missing Dreamstone trade with the Queen Bee