### PR TITLE
Integral Components and Charms

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 🌟 Improvements
 
--   [Expert] Adjusted Integral Components recipes to make automating them somewhat easier [\#905](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/905)
+-   [Expert] Adjusted Integral Components recipes to make automating them somewhat easier [\#904](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/904)
 
 ### Enigmatica 9 v1.20.1
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🌟 Improvements
 
 -   [Expert] Adjusted Integral Components recipes to make automating them somewhat easier [\#904](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/904)
+-   Add more fun uses for Ars charms [\#904](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/904)
 
 ### Enigmatica 9 v1.20.1
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Enigmatica 9 v1.20.0
+
+### 🌟 Improvements
+
+-   [Expert] Adjusted Integral Components recipes to make automating them somewhat easier [\#905](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/905)
+
 ### Enigmatica 9 v1.20.1
 
 🚀 Forge-1.19.2-43.2.14 | [📜 Mod Updates](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/changelog_mods_1.20.1.md) | [📋 Modlist](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/modlist_1.20.1.md)

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   [Expert] Adjusted Integral Components recipes to make automating them somewhat easier [\#904](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/904)
 -   Add more fun uses for Ars charms [\#904](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/904)
+-   Cicadas, Fireflies, and Backpacks will no longer generate with Apotheosis Affixes [\#904](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/904)
 
 ### Enigmatica 9 v1.20.1
 

--- a/config/configswapper/expert/config/apotheosis/adventure.cfg
+++ b/config/configswapper/expert/config/apotheosis/adventure.cfg
@@ -41,6 +41,14 @@ affixes {
     # A list of type overrides for the affix loot system.  Format is <itemname>|chance|<type>.  Types are SWORD, TRIDENT, SHIELD, HEAVY_WEAPON, BREAKER, CROSSBOW, BOW [default: [minecraft:iron_sword|SWORD]]
     S:"Equipment Type Overrides" <
         minecraft:iron_sword|SWORD
+        twilightforest:firefly|NONE  
+        twilightforest:cicada|NONE
+        sophisticatedbackpacks:backpack|NONE 
+        sophisticatedbackpacks:iron_backpack|NONE
+        sophisticatedbackpacks:gold_backpack|NONE
+        sophisticatedbackpacks:copper_backpack|NONE
+        sophisticatedbackpacks:diamond_backpack|NONE  
+        sophisticatedbackpacks:netherite_backpack|NONE
      >
 
     # The flat bonus chance that bosses have to drop a gem, added to Gem Drop Chance. 0 = 0%, 1 = 100% [range: 0.0 ~ 1.0, default: 0.33]

--- a/config/configswapper/normal/config/apotheosis/adventure.cfg
+++ b/config/configswapper/normal/config/apotheosis/adventure.cfg
@@ -41,6 +41,14 @@ affixes {
     # A list of type overrides for the affix loot system.  Format is <itemname>|chance|<type>.  Types are SWORD, TRIDENT, SHIELD, HEAVY_WEAPON, BREAKER, CROSSBOW, BOW [default: [minecraft:iron_sword|SWORD]]
     S:"Equipment Type Overrides" <
         minecraft:iron_sword|SWORD
+        twilightforest:firefly|NONE  
+        twilightforest:cicada|NONE
+        sophisticatedbackpacks:backpack|NONE 
+        sophisticatedbackpacks:iron_backpack|NONE
+        sophisticatedbackpacks:gold_backpack|NONE
+        sophisticatedbackpacks:copper_backpack|NONE
+        sophisticatedbackpacks:diamond_backpack|NONE  
+        sophisticatedbackpacks:netherite_backpack|NONE
      >
 
     # The flat bonus chance that bosses have to drop a gem, added to Gem Drop Chance. 0 = 0%, 1 = 100% [range: 0.0 ~ 1.0, default: 0.33]

--- a/kubejs/server_scripts/base/recipes/minecraft/cooking.js
+++ b/kubejs/server_scripts/base/recipes/minecraft/cooking.js
@@ -1,0 +1,75 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:base/minecraft/';
+    const recipes = [
+        {
+            input: 'ars_nouveau:drygmy_charm',
+            output: Item.of('minecraft:cooked_mutton', {
+                display: { Name: '{"text":"Roast Drygmy Shank", "color":"gold"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_drygmy_charm`
+        },
+        {
+            input: 'ars_nouveau:amethyst_golem_charm',
+            output: Item.of('supplementaries:candy', {
+                display: { Name: '{"text":"Rock Candy", "color":"dark_purple"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_amethyst_golem_charm`
+        },
+        {
+            input: 'ars_elemental:siren_charm',
+            output: Item.of('farmersdelight:cooked_salmon_slice', {
+                display: { Name: '{"text":"Smoked Siren Filet", "color":"aqua"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_siren_charm`
+        },
+        {
+            input: 'ars_elemental:firenando_charm',
+            output: Item.of('farmersdelight:smoked_ham', {
+                display: { Name: '{"text":"Toasted SPAM", "color":"red"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_firenando_charm`
+        },
+        {
+            input: 'ars_nouveau:starbuncle_charm',
+            output: Item.of('minecraft:cooked_rabbit', {
+                display: { Name: '{"text":"Roast Starbuncle", "color":"gold"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_starbuncle_charm`
+        },
+        {
+            input: 'ars_nouveau:whirlisprig_charm',
+            output: Item.of('farmersdelight:cabbage_rolls', {
+                display: { Name: '{"text":"Sprig Rolls", "color":"green"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_whirlisprig_charm`
+        },
+        {
+            input: 'ars_nouveau:wixie_charm',
+            output: Item.of('thermal:cooked_mushroom', {
+                display: { Name: '{"text":"Sautéed Wixie Cap", "color":"dark_purple"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_wixie_charm`
+        },
+        {
+            input: 'ars_nouveau:bookwyrm_charm',
+            output: Item.of('farmersdelight:cooked_chicken_cuts', {
+                display: { Name: '{"text":"Wild Wyrm Wings", "color":"dark_purple"}' }
+            }),
+            xp: 0.35,
+            id_suffix: `cooked_bookwyrm_charm`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.smoking(recipe.output, recipe.input).xp(recipe.xp).id(`${id_prefix}smoking/${recipe.id_suffix}`);
+        event.smelting(recipe.output, recipe.input).xp(recipe.xp).id(`${id_prefix}smelting/${recipe.id_suffix}`);
+        event.campfireCooking(recipe.output, recipe.input).xp(recipe.xp).id(`${id_prefix}campfire/${recipe.id_suffix}`);
+    });
+});

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
@@ -393,50 +393,42 @@ ServerEvents.recipes((event) => {
         {
             output: 'thermal:upgrade_augment_1',
             inputs: [
+                '#industrialforegoing:machine_frame/simple',
                 'ae2:spatial_cell_component_2',
                 '#forge:gears/compressed_iron',
-                'immersiveengineering:component_electronic',
+                'immersiveengineering:electron_tube',
                 '#forge:gears/compressed_iron',
-                'ae2:spatial_cell_component_2',
-                '#forge:gears/compressed_iron',
-                'immersiveengineering:component_electronic',
-                '#forge:gears/compressed_iron'
+                'ae2:spatial_cell_component_2'
             ],
-            reagents: ['#industrialforegoing:machine_frame/simple'],
+            reagents: ['immersiveengineering:component_electronic'],
             sourceCost: 1000,
             id: `${id_prefix}upgrade_augment_1`
         },
         {
             output: Item.of('thermal:upgrade_augment_2', '{AugmentData:{BaseMod:4,Type:"Upgrade"}}'),
             inputs: [
-                'thermal:upgrade_augment_1',
+                '#industrialforegoing:machine_frame/advanced',
                 'ae2:spatial_cell_component_2',
                 '#forge:gears/diamond',
                 'pneumaticcraft:printed_circuit_board',
                 '#forge:gears/diamond',
-                'ae2:spatial_cell_component_2',
-                '#forge:gears/diamond',
-                'pneumaticcraft:printed_circuit_board',
-                '#forge:gears/diamond'
+                'ae2:spatial_cell_component_2'
             ],
-            reagents: ['#industrialforegoing:machine_frame/advanced'],
+            reagents: ['thermal:upgrade_augment_1'],
             sourceCost: 5000,
             id: `${id_prefix}upgrade_augment_2`
         },
         {
             output: Item.of('thermal:upgrade_augment_3', '{AugmentData:{BaseMod:8,Type:"Upgrade"}}'),
             inputs: [
-                'thermal:upgrade_augment_2',
+                '#industrialforegoing:machine_frame/supreme',
                 'ae2:spatial_cell_component_2',
                 '#forge:gears/netherite',
                 'pneumaticcraft:printed_circuit_board',
                 '#forge:gears/netherite',
-                'ae2:spatial_cell_component_2',
-                '#forge:gears/netherite',
-                'pneumaticcraft:printed_circuit_board',
-                '#forge:gears/netherite'
+                'ae2:spatial_cell_component_2'
             ],
-            reagents: ['#industrialforegoing:machine_frame/supreme'],
+            reagents: ['thermal:upgrade_augment_2'],
             sourceCost: 10000,
             id: `${id_prefix}upgrade_augment_3`
         },


### PR DESCRIPTION
-   [Expert] Adjusted Integral Components recipes to make automating them somewhat easier
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/b77b7191-b197-4f83-be6b-df6d15a64181)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/3e3e377b-350b-4503-af53-cb18bcab151a)
![image](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/9543430/09c9b4f8-ee69-4cc1-8a06-8252e7d69876)

The main difference here is that some other recipes use the machine frames on the pedestals, while these used to use them as the central item. This meant dealing with this via filters was clunky. 

-   Add more fun uses for Ars charms 
 -   Cicadas, Fireflies, and Backpacks will no longer generate with Apotheosis Affixes. This is mostly to reduce clutter with fireflies and cicadas, but it also removes confusion with backpacks as the affixes only work if worn as an actual chest piece. https://github.com/EnigmaticaModpacks/Enigmatica9/issues/903