### PR TITLE
Fix Wind Shear and Quests

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Adds several community suggested Caster Tomes to loot! [\#906](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/906)
 -   [Expert] Teleportation rituals now inform the player why they failed if executed in the wrong dimension [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   [Expert] Motes now require regular potions instead of lingering potions [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
+-   [Expert] Wind Shear glyph now uses Skyseeker's Blade instead of Iron Swords [\#917](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/917)
 
 ### 🐛 Fixed Bugs
 
@@ -16,6 +17,7 @@
 -   Fixed an issue with Gateways crashing the game if used in a Compact Machine [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   [Expert] Mekanism tanks may no longer be upgraded in world [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   Fix missing stripped log/wood tags [\#915](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/915)
+-   [Expert] Occultism quests no longer require otherworld ash [\#917](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/917)
 
 ### Enigmatica 9 v1.20.1
 

--- a/config/ftbquests/quests/chapters/occultism_expert.snbt
+++ b/config/ftbquests/quests/chapters/occultism_expert.snbt
@@ -143,8 +143,6 @@
 				"Communication and Trade with the Otherworld are feasible and safe for the acolyte, though some specialized materials will be required to begin. "
 				""
 				"Purified Ink is the only known substance suitable for transcribing the names of Spirits for use in ritual magic. Anything else has a strange tendency to fade, as if it would rather not be involved. "
-				""
-				"Burnt Otherstone and Otherworld Ashes may be combined and purified to form a specialized form of chalk suitable for drawing the ritual circles used in rituals. "
 			]
 			hide_dependency_lines: true
 			id: "5779806AB9F94AC5"
@@ -173,11 +171,6 @@
 				{
 					id: "68921B19CAED8BD1"
 					item: "occultism:purified_ink"
-					type: "item"
-				}
-				{
-					id: "72C9477A65D081AC"
-					item: "occultism:otherworld_ashes"
 					type: "item"
 				}
 				{

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
@@ -167,6 +167,19 @@ ServerEvents.recipes((event) => {
             count: 1,
             exp: 55,
             id: 'ars_elemental:glyph_envenom'
+        },
+        {
+            output: 'ars_nouveau:glyph_wind_shear',
+            inputItems: [
+                { item: { tag: 'forge:essences/air' } },
+                { item: { item: 'naturesaura:sky_sword' } },
+                { item: { item: 'naturesaura:sky_sword' } },
+                { item: { item: 'naturesaura:sky_sword' } },
+                { item: { item: 'supplementaries:antique_ink' } }
+            ],
+            count: 1,
+            exp: 55,
+            id: 'ars_nouveau:glyph_wind_shear'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
@@ -19,7 +19,7 @@ ServerEvents.recipes((event) => {
         {
             output: 'toomanyglyphs:glyph_chaining',
             inputItems: [
-                { item: { item: 'ars_nouveau:manipulation_essence' } },
+                { item: { tag: 'forge:essences/manipulation' } },
                 { item: { item: 'minecraft:chain' } },
                 { item: { item: 'minecraft:chain' } },
                 { item: { item: 'minecraft:chain' } },
@@ -38,7 +38,7 @@ ServerEvents.recipes((event) => {
                 { item: { item: 'quark:rainbow_rune' } },
                 { item: { item: 'minecraft:prismarine_shard' } },
                 { item: { item: 'ars_nouveau:bastion_pod' } },
-                { item: { item: 'ars_nouveau:water_essence' } },
+                { item: { tag: 'forge:essences/water' } },
                 { item: { item: 'supplementaries:antique_ink' } }
             ],
             count: 1,


### PR DESCRIPTION
-   [Expert] Wind Shear glyph now uses Skyseeker's Blade instead of Iron Swords 
- [Expert] Occultism quests no longer require otherworld ash https://github.com/EnigmaticaModpacks/Enigmatica9/issues/916