### PR TITLE
Small fixes

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   [Expert] Teleportation rituals now inform the player why they failed if executed in the wrong dimension [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   [Expert] Motes now require regular potions instead of lingering potions [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   [Expert] Wind Shear glyph now uses Skyseeker's Blade instead of Iron Swords [\#917](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/917)
+-   [Expert] Skyseeker's Boots no longer provide step up. [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -9,7 +9,8 @@
 -   [Expert] Teleportation rituals now inform the player why they failed if executed in the wrong dimension [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   [Expert] Motes now require regular potions instead of lingering potions [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   [Expert] Wind Shear glyph now uses Skyseeker's Blade instead of Iron Swords [\#917](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/917)
--   [Expert] Skyseeker's Boots no longer provide step up. [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
+-   [Expert] Skyseeker's Boots no longer provide step up [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
+-   Hexerei drying rack quests now accept any drying rack [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   [Expert] Wind Shear glyph now uses Skyseeker's Blade instead of Iron Swords [\#917](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/917)
 -   [Expert] Skyseeker's Boots no longer provide step up [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 -   Hexerei drying rack quests now accept any drying rack [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
+-   [Expert] Ars Nouveau threads that require a familiar shard now also accept the corresponding charm [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   [Expert] Mekanism tanks may no longer be upgraded in world [\#912](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/912)
 -   Fix missing stripped log/wood tags [\#915](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/915)
 -   [Expert] Occultism quests no longer require otherworld ash [\#917](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/917)
+-   [Expert] Fix broken Parrot Familiar summon [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 
 ### Enigmatica 9 v1.20.1
 

--- a/config/ftbquests/quests/chapters/hexerei.snbt
+++ b/config/ftbquests/quests/chapters/hexerei.snbt
@@ -209,8 +209,33 @@
 			]
 			subtitle: "High and Dry"
 			tasks: [{
+				icon: "hexerei:herb_drying_rack"
 				id: "1BA14B4A6E3CE766"
-				item: "hexerei:herb_drying_rack"
+				item: {
+					Count: 1b
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "hexerei:herb_drying_rack"
+							}
+							{
+								Count: 1b
+								id: "hexerei:mahogany_drying_rack"
+							}
+							{
+								Count: 1b
+								id: "hexerei:willow_drying_rack"
+							}
+							{
+								Count: 1b
+								id: "hexerei:witch_hazel_drying_rack"
+							}
+						]
+					}
+				}
+				title: "Drying Rack"
 				type: "item"
 			}]
 			x: 8.0d

--- a/config/ftbquests/quests/chapters/hexerei_expert.snbt
+++ b/config/ftbquests/quests/chapters/hexerei_expert.snbt
@@ -209,8 +209,33 @@
 			]
 			subtitle: "High and Dry"
 			tasks: [{
+				icon: "hexerei:herb_drying_rack"
 				id: "0429E8C49A97273F"
-				item: "hexerei:herb_drying_rack"
+				item: {
+					Count: 1b
+					id: "itemfilters:or"
+					tag: {
+						items: [
+							{
+								Count: 1b
+								id: "hexerei:herb_drying_rack"
+							}
+							{
+								Count: 1b
+								id: "hexerei:mahogany_drying_rack"
+							}
+							{
+								Count: 1b
+								id: "hexerei:willow_drying_rack"
+							}
+							{
+								Count: 1b
+								id: "hexerei:witch_hazel_drying_rack"
+							}
+						]
+					}
+				}
+				title: "Drying Rack"
 				type: "item"
 			}]
 			x: 8.0d

--- a/kubejs/server_scripts/expert/player_events/armor_sets.js
+++ b/kubejs/server_scripts/expert/player_events/armor_sets.js
@@ -31,10 +31,6 @@ const armor_sets = [
         effects: [{ potion: 'ars_nouveau:glide', amp: 0 }]
     },
     {
-        armor: [null, null, null, 'naturesaura:sky_shoes'],
-        effects: [{ potion: 'occultism:step_height', amp: 1 }]
-    },
-    {
         armor: [
             'naturesaura:depth_helmet',
             'naturesaura:depth_chest',

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/enchanting_apparatus.js
@@ -895,6 +895,64 @@ ServerEvents.recipes((event) => {
             reagents: ['ars_nouveau:relay'],
             sourceCost: 0,
             id: 'ars_nouveau:relay_warp'
+        },
+        {
+            output: 'ars_nouveau:thread_starbuncle',
+            inputs: [
+                Ingredient.of(['ars_nouveau:starbuncle_shards', 'ars_nouveau:starbuncle_charm']),
+                Ingredient.of(['ars_nouveau:starbuncle_shards', 'ars_nouveau:starbuncle_charm']),
+                Ingredient.of(['ars_nouveau:starbuncle_shards', 'ars_nouveau:starbuncle_charm']),
+                'minecraft:sugar',
+                'minecraft:sugar',
+                'minecraft:sugar',
+                '#forge:essences/manipulation',
+                '#forge:essences/manipulation'
+            ],
+            reagents: ['ars_nouveau:blank_thread'],
+            sourceCost: 0,
+            id: 'ars_nouveau:thread_starbuncle'
+        },
+        {
+            output: 'ars_nouveau:thread_whirlisprig',
+            inputs: [
+                Ingredient.of(['ars_nouveau:whirlisprig_shards', 'ars_nouveau:whirlisprig_charm']),
+                Ingredient.of(['ars_nouveau:whirlisprig_shards', 'ars_nouveau:whirlisprig_charm']),
+                Ingredient.of(['ars_nouveau:whirlisprig_shards', 'ars_nouveau:whirlisprig_charm']),
+                '#forge:essences/earth',
+                '#forge:essences/earth',
+                'minecraft:golden_apple'
+            ],
+            reagents: ['ars_nouveau:blank_thread'],
+            sourceCost: 0,
+            id: 'ars_nouveau:thread_whirlisprig'
+        },
+        {
+            output: 'ars_nouveau:thread_wixie',
+            inputs: [
+                Ingredient.of(['ars_nouveau:wixie_shards', 'ars_nouveau:wixie_charm']),
+                Ingredient.of(['ars_nouveau:wixie_shards', 'ars_nouveau:wixie_charm']),
+                Ingredient.of(['ars_nouveau:wixie_shards', 'ars_nouveau:wixie_charm']),
+                '#forge:essences/abjuration',
+                '#forge:essences/abjuration',
+                '#forge:rods/blaze'
+            ],
+            reagents: ['ars_nouveau:blank_thread'],
+            sourceCost: 0,
+            id: 'ars_nouveau:thread_wixie'
+        },
+        {
+            output: 'ars_nouveau:thread_drygmy',
+            inputs: [
+                Ingredient.of(['ars_nouveau:drygmy_shard', 'ars_nouveau:drygmy_charm']),
+                Ingredient.of(['ars_nouveau:drygmy_shard', 'ars_nouveau:drygmy_charm']),
+                Ingredient.of(['ars_nouveau:drygmy_shard', 'ars_nouveau:drygmy_charm']),
+                '#forge:essences/earth',
+                '#forge:essences/earth',
+                Ingredient.of(['minecraft:rabbit_foot', 'apotheosis:lucky_foot'])
+            ],
+            reagents: ['ars_nouveau:blank_thread'],
+            sourceCost: 0,
+            id: 'ars_nouveau:thread_drygmy'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
+++ b/kubejs/server_scripts/expert/recipes/ars_nouveau/glyph.js
@@ -180,6 +180,18 @@ ServerEvents.recipes((event) => {
             count: 1,
             exp: 55,
             id: 'ars_nouveau:glyph_wind_shear'
+        },
+        {
+            output: 'ars_nouveau:glyph_sense_magic',
+            inputItems: [
+                { item: { tag: 'forge:essences/abjuration' } },
+                { item: { item: 'ars_nouveau:dowsing_rod' } },
+                { item: { item: 'ars_nouveau:starbuncle_charm' } },
+                { item: { item: 'supplementaries:antique_ink' } }
+            ],
+            count: 1,
+            exp: 55,
+            id: 'ars_nouveau:glyph_sense_magic'
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/occultism/ritual.js
+++ b/kubejs/server_scripts/expert/recipes/occultism/ritual.js
@@ -642,11 +642,10 @@ ServerEvents.recipes((event) => {
                     Lore: ['{"translate":"item.occultism.ritual_dummy.familiar_parrot.tooltip"}']
                 }
             }),
-            ritual_type: 'occultism:summon_with_chance_of_chicken_tamed',
             activation_item: '#forge:essences/conjuration',
             pentacle_id: 'occultism:summon_familiar',
             entity_to_summon: 'minecraft:parrot',
-            ritual_type: 'occultism:familiar',
+            ritual_type: 'occultism:summon_tamed',
             ritual_dummy: 'occultism:ritual_dummy/familiar_parrot',
             inputs: [
                 'hexerei:mindful_trance_blend',


### PR DESCRIPTION
-   [Expert] Skyseeker's Boots no longer provide step up. Even setting it to a lower height was too much and there's no good way to disable it.  https://github.com/EnigmaticaModpacks/Enigmatica9/issues/919
- Hexerei drying rack quests now accept any drying rack https://github.com/EnigmaticaModpacks/Enigmatica9/issues/918
-   [Expert] Ars Nouveau threads that require a familiar shard now also accept the corresponding charm 
-   [Expert] Fix broken Parrot Familiar summon