### PR TITLE
Golems and Teleporters

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   [Expert] Ars Nouveau threads that require a familiar shard now also accept the corresponding charm [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 -   [Expert] Adjust ratio of dimension shards to metal crystals [\#922](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/922)
 -   Clarify Create quests for straws [\#923](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/923)
--   Tablet of Awakening quest no longer requires an Amethyst Golem Charm [\#924](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/924)
+-   Tablet of Awakening quest no longer requires an Amethyst Golem Charm [\#926](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/926)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   [Expert] Adjust ratio of dimension shards to metal crystals [\#922](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/922)
 -   Clarify Create quests for straws [\#923](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/923)
 -   Tablet of Awakening quest no longer requires an Amethyst Golem Charm [\#926](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/926)
+-   [Expert] Mekanism Teleporter Frames now craft in batches of 9 [\#926](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/926)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   [Expert] Ars Nouveau threads that require a familiar shard now also accept the corresponding charm [\#920](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/920)
 -   [Expert] Adjust ratio of dimension shards to metal crystals [\#922](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/922)
 -   Clarify Create quests for straws [\#923](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/923)
+-   Tablet of Awakening quest no longer requires an Amethyst Golem Charm [\#924](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/924)
 
 ### 🐛 Fixed Bugs
 

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -1787,18 +1787,11 @@
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
-			tasks: [
-				{
-					id: "0E7FDC5948AB7296"
-					item: "ars_nouveau:ritual_awakening"
-					type: "item"
-				}
-				{
-					id: "68A25EFE4671BDAC"
-					item: "ars_nouveau:amethyst_golem_charm"
-					type: "item"
-				}
-			]
+			tasks: [{
+				id: "0E7FDC5948AB7296"
+				item: "ars_nouveau:ritual_awakening"
+				type: "item"
+			}]
 			x: 2.5d
 			y: 3.0d
 		}

--- a/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau_expert.snbt
@@ -1767,18 +1767,11 @@
 				title: "Sorcerer's Delight"
 				type: "command"
 			}]
-			tasks: [
-				{
-					id: "2AB5E8ADCF71D9C9"
-					item: "ars_nouveau:ritual_awakening"
-					type: "item"
-				}
-				{
-					id: "7B469A83BA2B79F1"
-					item: "ars_nouveau:amethyst_golem_charm"
-					type: "item"
-				}
-			]
+			tasks: [{
+				id: "2AB5E8ADCF71D9C9"
+				item: "ars_nouveau:ritual_awakening"
+				type: "item"
+			}]
 			x: 2.0d
 			y: 3.0d
 		}

--- a/kubejs/server_scripts/expert/recipes/mekanism/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/mekanism/shaped.js
@@ -6,7 +6,7 @@ ServerEvents.recipes((event) => {
 
     const recipes = [
         {
-            output: '8x mekanism:teleporter_frame',
+            output: '9x mekanism:teleporter_frame',
             pattern: ['ABA', 'BCB', 'ABA'],
             key: {
                 A: 'ars_nouveau:sourcestone',


### PR DESCRIPTION
- Tablet of Awakening quest no longer requires an Amethyst Golem Charm https://github.com/EnigmaticaModpacks/Enigmatica9/issues/924
-  [Expert] Mekanism Teleporter Frames now craft in batches of 9  https://github.com/EnigmaticaModpacks/Enigmatica9/issues/925