### PR TITLE
Reintroduce Mechanical Visor Upgrade to Expert mode

### DIFF
--- a/kubejs/client_scripts/constants/jei_hidden_disabled.js
+++ b/kubejs/client_scripts/constants/jei_hidden_disabled.js
@@ -310,7 +310,6 @@ jei.expert.items.disabled = [
     'compressedcreativity:brass_coated_upgrade_matrix',
     'compressedcreativity:rotational_compressor',
     'compressedcreativity:heater',
-    'compressedcreativity:mechanical_visor_upgrade',
 
     'emendatusenigmatica:refined_glowstone_nugget',
     'emendatusenigmatica:refined_glowstone_ingot',

--- a/kubejs/client_scripts/expert/textures.js
+++ b/kubejs/client_scripts/expert/textures.js
@@ -70,6 +70,16 @@ ClientEvents.highPriorityAssets((event) => {
             }
         },
         {
+            path: 'compressedcreativity:models/item/mechanical_visor_upgrade',
+            json_model: {
+                parent: 'item/generated',
+                textures : {
+                  "layer0" : "pneumaticcraft:item/upgrades/upgrade_layer0",
+                  "layer1" : "compressedcreativity:item/mechanical_visor_upgrade"
+                }
+            }
+        },
+        {
             path: 'occultism:models/block/sacrificial_bowl',
             json_model: {
                 credit: 'Made with Blockbench',

--- a/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/expert/recipes/enigmatica/remove.js
@@ -135,6 +135,7 @@ ServerEvents.recipes((event) => {
         { id: 'compressedcreativity:mixing/brass_gilded_lapis_lazuli' },
         { id: 'compressedcreativity:compacting/brass_coated_upgrade_matrix' },
         { id: 'compressedcreativity:crafting/rotational_compressor' },
+        { id: 'compressedcreativity:crafting/mechanical_visor_upgrade' },
 
         { id: /emendatusenigmatica:plate\/from_ingot/ },
         { id: /emendatusenigmatica:rod\/from_ingot/ },

--- a/kubejs/server_scripts/expert/recipes/thermal/smelter.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/smelter.js
@@ -292,6 +292,16 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}scuba_upgrade`
         },
         {
+            result: [{ item: 'compressedcreativity:mechanical_visor_upgrade', count: 1 }],
+            ingredients: [
+                { item: 'pneumaticcraft:upgrade_matrix' },
+                { item: 'create:goggles' },
+                { tag: 'forge:essences/manipulation', count: 2 }
+            ],
+            energy: 8000,
+            id: `${id_prefix}mechanical_visor_upgrade`
+        },
+        {
             result: [{ item: 'ae2:fluix_pearl', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/subzero' },


### PR DESCRIPTION
![_enigmatica_expert_thermal_smelter_mechanical_visor_upgrade](https://github.com/EnigmaticaModpacks/Enigmatica9/assets/16291541/07921198-5c9b-43dc-8887-297881d04387)

I feel like it deserves to stay given its functionality is beyond acting like Engineer's Goggles. I changed the Expert Mode texture to use default PNC upgrade as a base and added a recipe that uses it as well, so no extra items are used.