### PR TITLE
Recipe conflicts

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   Immersive Engineering Sawdust flooring changed to no longer conflict with thermal [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 -   Crafting tables may now be converted to variants with the stonecutter. Variant shaped crafting recipes are removed. [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 -   Remove conflicting furnace recipe. Furnaces are now only crafted with cobblestone [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
+-   Remove conflicting chest recipe. Vanilla chest may be crafted by converting any other chest. [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 
 ### Enigmatica 9 v1.21.0
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   Added crafting recipes for many stone variants [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   [Expert] Motes now craft 1:1 with their potion to avoid leftovers [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   [Expert] Several Iron using recipes have been tweaked to adjust their gating [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
+-   Crafting tables may now be converted to variants with the stonecutter. Variant shaped crafting recipes are removed. [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 
 ### 🐛 Fixed Bugs
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   Removed reference to step height bonus on Skyseeker's armor [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   Immersive Engineering Sawdust flooring changed to no longer conflict with thermal [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 -   Crafting tables may now be converted to variants with the stonecutter. Variant shaped crafting recipes are removed. [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
+-   Remove conflicting furnace recipe. Furnaces are now only crafted with cobblestone [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 
 ### Enigmatica 9 v1.21.0
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,7 +14,6 @@
 -   Added crafting recipes for many stone variants [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   [Expert] Motes now craft 1:1 with their potion to avoid leftovers [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   [Expert] Several Iron using recipes have been tweaked to adjust their gating [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
--   Crafting tables may now be converted to variants with the stonecutter. Variant shaped crafting recipes are removed. [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 
 ### 🐛 Fixed Bugs
 
@@ -22,6 +21,8 @@
 -   [Expert] Disable a coal gen that was missed [\#952](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/952)
 -   [Expert] Fixed typo in Storage Actuator quest in chapter 2 [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   Removed reference to step height bonus on Skyseeker's armor [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
+-   Immersive Engineering Sawdust flooring changed to no longer conflict with thermal [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
+-   Crafting tables may now be converted to variants with the stonecutter. Variant shaped crafting recipes are removed. [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 
 ### Enigmatica 9 v1.21.0
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   Added crafting recipes for many stone variants [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   [Expert] Motes now craft 1:1 with their potion to avoid leftovers [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
 -   [Expert] Several Iron using recipes have been tweaked to adjust their gating [\#961](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/961)
+-   [Expert] Add a recipe for the new chunkloader upgrade for PNC drones [\#966](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/966)
 
 ### 🐛 Fixed Bugs
 

--- a/kubejs/server_scripts/base/recipes/ars_nouveau/shaped.js
+++ b/kubejs/server_scripts/base/recipes/ars_nouveau/shaped.js
@@ -1,0 +1,26 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:expert/ars_nouveau/shaped/';
+
+    const recipes = [
+        {
+            output: '4x ars_nouveau:sourcestone_stairs',
+            pattern: ['A  ', 'AA ', 'AAA'],
+            key: {
+                A: 'ars_nouveau:sourcestone'
+            },
+            id: `${id_prefix}sourcestone_stairs`
+        },
+        {
+            output: '6x ars_nouveau:sourcestone_slab',
+            pattern: ['AAA'],
+            key: {
+                A: 'ars_nouveau:sourcestone'
+            },
+            id: `${id_prefix}sourcestone_slab`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/ars_scalaes/shaped.js
+++ b/kubejs/server_scripts/base/recipes/ars_scalaes/shaped.js
@@ -1,0 +1,18 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:expert/ars_scalaes/shaped/';
+
+    const recipes = [
+        {
+            output: '6x ars_scalaes:smooth_sourcestone_wall',
+            pattern: ['AAA', 'AAA'],
+            key: {
+                A: 'ars_nouveau:smooth_sourcestone'
+            },
+            id: `${id_prefix}smooth_sourcestone_wall`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -147,6 +147,7 @@ ServerEvents.recipes((event) => {
 
         { id: 'quark:tweaks/smelting/bone_meal_utility' },
         { id: 'quark:building/crafting/furnaces/cobblestone_furnace' },
+        { id: 'quark:building/crafting/chests/mixed_chest' },
 
         { id: 'rftoolsbase:dimensionalshard' },
 

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -43,6 +43,8 @@ ServerEvents.recipes((event) => {
 
         { id: /ars_nouveau:.*_dye/ },
 
+        { id: /ars_scalaes:.*sourcestone.*(slab|stair)$/ },
+
         { id: 'byg:dye_from_warped_cactus' },
         { id: 'byg:dye_from_oddity_cactus' },
         { id: 'byg:byg_chest' },
@@ -58,15 +60,18 @@ ServerEvents.recipes((event) => {
         { id: 'create:milling/dripstone_block' },
         { id: 'create:milling/bone' },
         { id: 'create:milling/andesite' },
+        { id: 'create:crafting/materials/andesite_alloy_block' },
 
         { id: /createaddition:mixing\/biomass/ },
         { id: /createaddition:crafting\/.*spool/ },
         { id: 'createaddition:crafting/barbed_wire' },
         { id: 'createaddition:crafting/redstone_relay' },
+        { id: 'createaddition:crafting/electrum_ingot' },
         { id: 'createaddition:crafting/connector' },
         { id: 'createaddition:crafting/accumulator_conversion' },
         { id: 'createaddition:compacting/seed_oil' },
         { id: 'createaddition:mixing/bioethanol' },
+        { id: 'createaddition:mixing/electrum' },
         { id: 'createaddition:mechanical_crafting/accumulator' },
         { id: 'createaddition:mechanical_crafting/tesla_coil' },
         { id: 'createaddition:mechanical_crafting/electric_motor' },

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -49,6 +49,7 @@ ServerEvents.recipes((event) => {
         { id: 'byg:jacaranda_boookshelf' },
         { id: 'byg:rainbow_eucalpytus_trapdoor' },
         { id: 'byg:rainbow_eucalpytus_door' },
+        { id: /byg:.*crafting_table/ },
 
         { id: 'create:compat/ae2/mixing/fluix_crystal' },
         { id: 'create:compat/byg/crushing/lignite_ore' },

--- a/kubejs/server_scripts/base/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/base/recipes/enigmatica/remove.js
@@ -146,6 +146,7 @@ ServerEvents.recipes((event) => {
         { id: 'powah:crafting/capacitor_basic_tiny' },
 
         { id: 'quark:tweaks/smelting/bone_meal_utility' },
+        { id: 'quark:building/crafting/furnaces/cobblestone_furnace' },
 
         { id: 'rftoolsbase:dimensionalshard' },
 

--- a/kubejs/server_scripts/base/recipes/immersiveengineering/shaped.js
+++ b/kubejs/server_scripts/base/recipes/immersiveengineering/shaped.js
@@ -9,6 +9,14 @@ ServerEvents.recipes((event) => {
                 A: '#forge:treated_wood'
             },
             id: `${id_prefix}stick_treated`
+        },
+        {
+            output: '6x immersiveengineering:sawdust',
+            pattern: ['AAA', 'AAA'],
+            key: {
+                A: '#forge:sawdust'
+            },
+            id: `immersiveengineering:crafting/sawdust`
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/minecraft/stonecutting.js
+++ b/kubejs/server_scripts/base/recipes/minecraft/stonecutting.js
@@ -26,6 +26,16 @@ ServerEvents.recipes((event) => {
             output: 'ars_nouveau:source_gem_block',
             input: 'emendatusenigmatica:source_block',
             id: `${id_prefix}emendatusenigmatica_to_ars_nouveau_source_gem_block`
+        },
+        {
+            output: 'ars_nouveau:sourcestone_stairs',
+            input: 'ars_nouveau:sourcestone',
+            id: `${id_prefix}sourcestone_to_ars_nouveau_sourcestone_stairs`
+        },
+        {
+            output: '2x ars_nouveau:sourcestone_slab',
+            input: 'ars_nouveau:sourcestone',
+            id: `${id_prefix}sourcestone_to_ars_nouveau_sourcestone_slab`
         }
     ];
 

--- a/kubejs/server_scripts/base/recipes/minecraft/stonecutting.js
+++ b/kubejs/server_scripts/base/recipes/minecraft/stonecutting.js
@@ -59,7 +59,8 @@ ServerEvents.recipes((event) => {
         `#forge:storage_blocks/carrot`,
         `#forge:storage_blocks/apple`,
         `#forge:storage_blocks/bamboo`,
-        `#forge:storage_blocks/sugar_cane`
+        `#forge:storage_blocks/sugar_cane`,
+        `#forge:workbench`
     ];
 
     conversionTypes.forEach((tag) => {

--- a/kubejs/server_scripts/base/tags/blocks/forge/workbenches.js
+++ b/kubejs/server_scripts/base/tags/blocks/forge/workbenches.js
@@ -1,3 +1,3 @@
 ServerEvents.tags('block', (event) => {
-    event.add('forge:workbenches', ['minecraft:crafting_table']);
+    event.add('forge:workbench', ['minecraft:crafting_table']);
 });

--- a/kubejs/server_scripts/base/tags/items/forge/workbenches.js
+++ b/kubejs/server_scripts/base/tags/items/forge/workbenches.js
@@ -1,3 +1,3 @@
 ServerEvents.tags('item', (event) => {
-    event.add('forge:workbenches', ['minecraft:crafting_table']);
+    event.add('forge:workbench', ['minecraft:crafting_table']);
 });

--- a/kubejs/server_scripts/expert/recipes/ae2/shapeless.js
+++ b/kubejs/server_scripts/expert/recipes/ae2/shapeless.js
@@ -12,12 +12,12 @@ ServerEvents.recipes((event) => {
         },
         {
             output: 'ae2:crafting_terminal',
-            inputs: ['#forge:workbenches', 'ae2:terminal'],
+            inputs: ['#forge:workbench', 'ae2:terminal'],
             id: `ae2:network/parts/terminals_crafting`
         },
         {
             output: 'ae2:crafting_terminal',
-            inputs: ['pneumaticcraft:logistics_core', '#ae2:illuminated_panel', '#forge:workbenches'],
+            inputs: ['pneumaticcraft:logistics_core', '#ae2:illuminated_panel', '#forge:workbench'],
             id: `${id_prefix}crafting_terminal`
         },
         {

--- a/kubejs/server_scripts/expert/recipes/thermal/smelter.js
+++ b/kubejs/server_scripts/expert/recipes/thermal/smelter.js
@@ -302,6 +302,16 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}mechanical_visor_upgrade`
         },
         {
+            result: [{ item: 'pneumaticcraft:chunkloader_upgrade', count: 1 }],
+            ingredients: [
+                { item: 'pneumaticcraft:upgrade_matrix' },
+                { item: 'create:content_observer' },
+                { tag: 'forge:essences/manipulation', count: 2 }
+            ],
+            energy: 8000,
+            id: `${id_prefix}chunkloader_upgrade`
+        },
+        {
             result: [{ item: 'ae2:fluix_pearl', count: 4 }],
             ingredients: [
                 { tag: 'forge:dusts/subzero' },


### PR DESCRIPTION
-   Crafting tables may now be converted to variants with the stonecutter. Variant shaped crafting recipes are removed. https://github.com/EnigmaticaModpacks/Enigmatica9/issues/965
- Immersive Engineering Sawdust flooring changed to no longer conflict with thermal
- Add Expert recipe for PNC's new drone chunkloader 