### PR TITLE
SushiGO

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🌟 Improvements
 
--   [Expert] Add recipes to transmute common materials from Twilight Forest into SushiGo materials, so sushi is more accessible.
+-   [Expert] Add recipes to transmute common materials from Twilight Forest into SushiGo materials, so sushi is more accessible. [\#979](https://github.com/EnigmaticaModpacks/Enigmatica9/issues/979)
 
 ### Enigmatica 9 v1.22.1
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Enigmatica 9 v1.23.0
+
+### 🎁 New Mods Added
+
+### 🌟 Improvements
+
+-   [Expert] Add recipes to transmute common materials from Twilight Forest into SushiGo materials, so sushi is more accessible.
+
 ### Enigmatica 9 v1.22.1
 
 🚀 Forge-1.19.2-43.2.14 | [📜 Mod Updates](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/changelog_mods_1.22.1.md) | [📋 Modlist](https://github.com/EnigmaticaModpacks/Enigmatica9/blob/master/changelogs/modlist_1.22.1.md)

--- a/kubejs/server_scripts/expert/recipes/naturesaura/altar.js
+++ b/kubejs/server_scripts/expert/recipes/naturesaura/altar.js
@@ -126,6 +126,38 @@ ServerEvents.recipes((event) => {
             aura: 500000,
             time: 1800,
             id: `${id_prefix}novice_spell_book`
+        },
+        {
+            output: Item.of('sushigocrafting:tobiko', '{Amount:100}'),
+            input: 'minecraft:sweet_berries',
+            catalyst: 'naturesaura:conversion_catalyst',
+            aura: 300,
+            time: 10,
+            id: `${id_prefix}tobiko`
+        },
+        {
+            output: 'sushigocrafting:raw_tuna',
+            input: 'minecraft:salmon',
+            catalyst: 'naturesaura:conversion_catalyst',
+            aura: 300,
+            time: 10,
+            id: `${id_prefix}raw_tuna`
+        },
+        {
+            output: Item.of('sushigocrafting:shrimp', '{Amount:100}'),
+            input: 'twilightforest:cicada',
+            catalyst: 'naturesaura:conversion_catalyst',
+            aura: 300,
+            time: 10,
+            id: `${id_prefix}shrimp_from_cicada`
+        },
+        {
+            output: Item.of('sushigocrafting:shrimp', '{Amount:100}'),
+            input: 'twilightforest:firefly',
+            catalyst: 'naturesaura:conversion_catalyst',
+            aura: 300,
+            time: 10,
+            id: `${id_prefix}shrimp_from_firefly`
         }
     ];
 


### PR DESCRIPTION
- Add recipes to transmute common materials from Twilight Forest into SushiGo materials, so sushi is more accessible. 