### PR TITLE
Train recipes rebalance

### DIFF
--- a/kubejs/server_scripts/expert/recipes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/expert/recipes/create/sequenced_assembly.js
@@ -22,6 +22,39 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}sky_dust_silver_osmium_clump`
+        },
+        {
+            results: [
+                { item: `create:track`, count: 64 },
+            ],
+            input: 'minecraft:smooth_stone_slab',
+            transitionalItem: 'minecraft:smooth_stone_slab',
+            loops: 1,
+            sequence: [
+                {
+                    type: 'create:deploying',
+                    ingredients: [
+                        { item: 'minecraft:smooth_stone_slab' },
+                        Ingredient.of(['emendatusenigmatica:bronze_rod', '#forge:rods/osmium', '#forge:rods/iron']).toJson()
+                    ],
+                    results: [{ item: 'minecraft:smooth_stone_slab' }]
+                },
+                {
+                    type: 'create:deploying',
+                    ingredients: [
+                        { item: 'minecraft:smooth_stone_slab' },
+                        Ingredient.of(['emendatusenigmatica:bronze_rod', '#forge:rods/osmium', '#forge:rods/iron']).toJson()
+                    ],
+                    results: [{ item: 'minecraft:smooth_stone_slab' }]
+                },
+                {
+                    type: 'create:pressing',
+                    ingredients: [{ item: 'minecraft:smooth_stone_slab' }],
+                    results: [{ item: 'minecraft:smooth_stone_slab' }],
+                    processingTime: 50
+                },
+            ],
+            id: `${id_prefix}track_sequential`
         }
     ];
 

--- a/kubejs/server_scripts/expert/recipes/create/shaped.js
+++ b/kubejs/server_scripts/expert/recipes/create/shaped.js
@@ -316,12 +316,12 @@ ServerEvents.recipes((event) => {
             id: `create:crafting/kinetics/rotation_speed_controller`
         },
         {
-            output: 'create:controls',
+            output: '2x create:controls',
             pattern: ['A', 'B', 'C'],
             key: {
-                A: 'immersiveengineering:component_electronic',
+                A: 'create:analog_lever',
                 B: 'create:railway_casing',
-                C: '#forge:gears/lumium'
+                C: 'immersiveengineering:component_electronic'
             },
             id: `create:crafting/kinetics/controls`
         },
@@ -353,34 +353,14 @@ ServerEvents.recipes((event) => {
             id: `create:crafting/kinetics/nixie_tube`
         },
         {
-            output: '32x create:track',
+            output: '64x create:track',
             pattern: ['ABA', 'ACA', 'ABA'],
             key: {
-                A: '#forge:rods/iron',
+                A: Ingredient.of(['emendatusenigmatica:bronze_rod', '#forge:rods/osmium', '#forge:rods/iron']),
                 B: 'minecraft:smooth_stone_slab',
                 C: '#forge:gravel'
             },
-            id: `${id_prefix}track_from_iron`
-        },
-        {
-            output: '48x create:track',
-            pattern: ['ABA', 'ACA', 'ABA'],
-            key: {
-                A: '#forge:rods/osmium',
-                B: 'minecraft:smooth_stone_slab',
-                C: '#forge:gravel'
-            },
-            id: `${id_prefix}track_from_osmium`
-        },
-        {
-            output: '16x create:track',
-            pattern: ['ABA', 'ACA', 'ABA'],
-            key: {
-                A: '#forge:rods/bronze',
-                B: 'minecraft:smooth_stone_slab',
-                C: '#forge:gravel'
-            },
-            id: `${id_prefix}track_from_bronze`
+            id: `${id_prefix}track_from_rods`
         },
         {
             output: 'create:smart_fluid_pipe',


### PR DESCRIPTION
This PR makes Create Train Tracks much cheaper to craft and Train Controls available in chapter 1.

# Motivation
Create Trains are amazing and most of us love them, but they are objectively worse automation option when compared to "industry titans" like AE2, and so to make players consider them as a practical option, trains must be very cheap, and, unfortunately, this is currently not the case in E9E:
- Train tracks are pretty expensive. Laying down a track to a nearby dungeon can easily take all the copper you mined from the nearby hollow hill or two
- Train Controls are gated midway into chapter 2. Due to lumium gear requirement, you can only start using trains at the point in the progression where you are also already have access to AE2 quantum ring, at which point trains are just a novelty choice for the most dedicated trains fans.

# Changes
## Train Controls
Recipe was changed to not require lumium gear. Instead, it was brought back to the default-ish Create look, but with analog lever instead of the lever, and with Imprinted Control Crystal instead of precision mechanism.
![image](https://github.com/user-attachments/assets/8d82899c-cf01-47a6-95c4-cf52ee9ed4b8)
## Tracks
- All shaped train tracks recipes were unified and now give 64 rails per craft. This was mostly done to preserve backwards-compatibility, since some players might have automated rails with iron or osmium rods.  
  ![image](https://github.com/user-attachments/assets/2e91f60e-72b9-45d2-8833-0ae08b60e1ad)
- A new sequential assembly recipe was added, for even cheaper train tracks, once the player reaches chapter 2.
  ![image](https://github.com/user-attachments/assets/6d0f75d7-ee21-449e-a6e4-0912bac5e89e)

---

Hopefully, after those changes, more people will consider using trains in their playthroughs.